### PR TITLE
Update macro method usage, after receiving undefined error in Mongoid 7.0

### DIFF
--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -12,6 +12,7 @@ module Formtastic
   autoload :InputClassFinder
   autoload :ActionClassFinder
   autoload :Deprecation
+  autoload :Reflection
 
   eager_autoload do
     autoload :I18n

--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -336,7 +336,8 @@ module Formtastic
       # generated input.
       def association_columns(*by_associations) # @private
         if @object.present? && @object.class.respond_to?(:reflections)
-          @object.class.reflections.collect do |name, association_reflection|
+          @object.class.reflections.collect do |name, reflection|
+            association_reflection = Formtastic::Reflection.new(reflection)
             if by_associations.present?
               if by_associations.include?(association_reflection.macro) && association_reflection.options[:polymorphic] != true
                 name

--- a/lib/formtastic/helpers/reflection.rb
+++ b/lib/formtastic/helpers/reflection.rb
@@ -6,9 +6,9 @@ module Formtastic
       # reflection object.
       def reflection_for(method) # @private
         if @object.class.respond_to?(:reflect_on_association)
-          @object.class.reflect_on_association(method)
+          reflection_on_association @object.class.reflect_on_association(method)
         elsif @object.class.respond_to?(:associations) # MongoMapper uses the 'associations(method)' instead
-          @object.class.associations[method]
+          reflection_on_association @object.class.associations[method]
         end
       end
 
@@ -19,18 +19,15 @@ module Formtastic
 
       def association_primary_key_for_method(method) # @private
         reflection = reflection_for(method)
-        if reflection
-          case association_macro_for_method(method)
-          when :has_and_belongs_to_many, :has_many, :references_and_referenced_in_many, :references_many
-            :"#{method.to_s.singularize}_ids"
-          else
-            return reflection.foreign_key.to_sym if reflection.respond_to?(:foreign_key)
-            return reflection.options[:foreign_key].to_sym unless reflection.options[:foreign_key].blank?
-            :"#{method}_id"
-          end
-        else
-          method.to_sym
-        end
+        reflection ? reflection.primary_key(method) : method.to_sym
+      end
+
+      private
+
+      def reflection_on_association(reflection)
+        return unless reflection
+
+        Formtastic::Reflection.new(reflection)
       end
     end
   end

--- a/lib/formtastic/reflection.rb
+++ b/lib/formtastic/reflection.rb
@@ -1,0 +1,34 @@
+module Formtastic
+  class Reflection
+    delegate :klass, to: :@_reflection
+
+    def initialize(reflection)
+      @_reflection = reflection
+    end
+
+    def options
+      return {} unless @_reflection.respond_to?(:options)
+
+      @_reflection.options
+    end
+
+    def macro
+      if @_reflection.respond_to?(:macro)
+        @_reflection.macro
+      else
+        @_reflection.class.name.demodulize.underscore.to_sym
+      end
+    end
+
+    def primary_key(method)
+      case macro
+      when :has_and_belongs_to_many, :has_many, :references_and_referenced_in_many, :references_many
+        :"#{method.to_s.singularize}_ids"
+      else
+        return @_reflection.foreign_key.to_sym if @_reflection.respond_to?(:foreign_key)
+        return @_reflection.options[:foreign_key].to_sym unless @_reflection.options[:foreign_key].blank?
+        :"#{method}_id"
+      end
+    end
+  end
+end

--- a/spec/reflection_spec.rb
+++ b/spec/reflection_spec.rb
@@ -1,0 +1,107 @@
+# encoding: utf-8
+require 'spec_helper'
+
+RSpec.describe 'Formtastic::Reflection' do
+
+  include FormtasticSpecHelper
+
+  before do
+    mock_everything
+  end
+
+  class ReflectionTester
+    def initialize(model_object)
+      @object = model_object
+    end
+
+    def macro
+      :belongs_to
+    end
+
+    def options
+      { foreign_key: 'reviewer_id' }
+    end
+  end
+
+  module Mongoid
+    class BelongsTo
+      def initialize(model_object)
+        @object = model_object
+      end
+
+      def options
+        { foreign_key: 'reviewer_id' }
+      end
+    end
+  end
+
+  let(:regular_reflection) { ReflectionTester.new(@new_post) }
+  let(:mongoid7_reflection) { Mongoid::BelongsTo.new(@new_post) }
+  let(:mongoid_reflection) do
+    ::MongoidReflectionMock.new('reflection',
+        :options => Proc.new { raise NoMethodError, "Mongoid has no reflection.options" },
+        :klass => ::Author, :macro => :referenced_in, :foreign_key => "reviewer_id")
+  end
+
+  describe '#macro' do
+    context 'reflection as regular object' do
+      it 'returns :belongs_to from macro method' do 
+        expect(Formtastic::Reflection.new(regular_reflection).macro).to eq(:belongs_to)
+      end
+    end
+
+    context 'reflection as mongoid < 7.0 object' do
+      it 'returns :referenced_in from macro method' do
+        expect(Formtastic::Reflection.new(mongoid_reflection).macro).to eq(:referenced_in)
+      end
+    end
+
+    context 'reflection as mongoid >= 7.0 object' do
+      it 'returns :belongs_to from class name' do
+        expect(Formtastic::Reflection.new(mongoid7_reflection).macro).to eq(:belongs_to)
+      end
+    end
+  end
+
+  describe '#primary_key' do
+    let(:method) { :reviewers }
+
+    context 'reflection as regular object' do
+      it 'returns :reviewer_id' do
+        expect(Formtastic::Reflection.new(regular_reflection).primary_key(method)).to eq(:reviewer_id)
+      end
+    end
+
+    context 'reflection as mongoid < 7.0 object' do
+      it 'returns :reviewer_id from foreign_key' do
+        expect(Formtastic::Reflection.new(mongoid_reflection).primary_key(method)).to eq(:reviewer_id)
+      end
+    end
+
+    context 'reflection as mongoid >= 7.0 object' do
+      it 'returns :reviewer_id from options method' do
+        expect(Formtastic::Reflection.new(mongoid7_reflection).primary_key(method)).to eq(:reviewer_id)
+      end
+    end
+  end
+
+  describe '#options' do
+    context 'reflection as regular object' do
+      it 'returns options with foreign key' do
+        expect(Formtastic::Reflection.new(regular_reflection).options).to eq({ foreign_key: 'reviewer_id' })
+      end
+    end
+
+    context 'reflection as mongoid < 7.0 object' do
+      it 'returns empty hash' do
+        expect(Formtastic::Reflection.new(mongoid_reflection).options).to eq({})
+      end
+    end
+
+    context 'reflection as mongoid >= 7.0 object' do
+      it 'returns options with foreign key' do
+        expect(Formtastic::Reflection.new(mongoid7_reflection).options).to eq({ foreign_key: 'reviewer_id' })
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** Mongoid with 7.0 patch removed file which contained `macro` method. Formtastic gem relies on this method in various places in code. Currently, projects which use Mongo 7.0 are having `undefined 'macro' method` error.
  - File path which contains `macro` method: https://github.com/mongodb/mongoid/blob/v6.4.4/lib/mongoid/relations/referenced/in.rb
  - A path where removed `relations` folder and forward files - removed: https://github.com/mongodb/mongoid/tree/v7.0.0/lib/mongoid

**Solution:** To avoid breaking current macro usage and fix the error for Mongoid 7.0 database based projects, a solution with `Proxy Object` was introduced in this pull request. Using Proxy Object allowed fixing macro method issue while keeping gem mostly intact. In the future, if other special issues will appear with the reflection object, fixing them will be easier by modifying this class.