### PR TITLE
Add a second scope for i18n enum to follow the syntax in Rails guides

### DIFF
--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -114,8 +114,11 @@ module Formtastic
 
             enum_options_hash = object.defined_enums[method_name]
             enum_options_hash.map do |name, value|
-              key = "activerecord.attributes.#{object_name}.#{method_name.pluralize}.#{name}"
-              label = ::I18n.translate(key, :default => name.humanize)
+              scopes = [
+                "activerecord.attributes.#{object_name}/#{method_name.pluralize}"
+                "activerecord.attributes.#{object_name}.#{method_name.pluralize}",
+              ]
+              label = ::I18n.translate(name, scope: scopes, :default => name.humanize)
               [label, name]
             end
           end

--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -115,8 +115,8 @@ module Formtastic
             enum_options_hash = object.defined_enums[method_name]
             enum_options_hash.map do |name, value|
               scopes = [
-                "activerecord.attributes.#{object_name}/#{method_name.pluralize}"
-                "activerecord.attributes.#{object_name}.#{method_name.pluralize}",
+                "activerecord.attributes.#{object_name}/#{method_name.pluralize}",
+                "activerecord.attributes.#{object_name}.#{method_name.pluralize}"
               ]
               label = ::I18n.translate(name, scope: scopes, :default => name.humanize)
               [label, name]


### PR DESCRIPTION
In Rails guides there is the two following paragraph about I18n and ActiveRecord:
- https://guides.rubyonrails.org/i18n.html#translations-for-active-record-models
- https://guides.rubyonrails.org/i18n.html#error-message-scopes

The guides talk about this

```yaml
en:
  activerecord:
    attributes:
      user/gender:
        female: "Female"
        male: "Male"
```

Instead of 


```yaml
en:
  activerecord:
    attributes:
      user:
        genders:
          female: "Female"
          male: "Male"
```

Since this I18n scope is present since 5 years ago, my PR add a second scope instead of changing it. That way we are able to use both, and not broke existing Rails applications.

I've to add tests. I just start this as a discussion before continuing that way.