### PR TITLE
Migrating to formtastic/formtastic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 ---
 
 See 3.0-stable branch for 3.0.x changes
-https://github.com/justinfrench/formtastic/blob/3.0-stable/CHANGELOG
+https://github.com/formtastic/formtastic/blob/3.0-stable/CHANGELOG
 
 See 2.3-stable branch for 2.3.x and earlier releases
-https://github.com/justinfrench/formtastic/blob/2.3-stable/CHANGELOG
+https://github.com/formtastic/formtastic/blob/2.3-stable/CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## master
+## master / 4.0.0.rc1
   * Fixed default_columns_for_object when object has non-standard foreign keys (#1241)
   * Fixed missing constants in production (#911)
   * Removed support for Rails 3 and 4.0 (#1108)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far e
 * [We track issues & bugs on GitHub](https://github.com/formtastic/formtastic/issues)
 * [We have a wiki on GitHub](https://github.com/formtastic/formtastic/wiki)
 * [StackOverflow can help](https://stackoverflow.com/questions/tagged/formtastic)
-* [Follow @formtastic on Twitter for news & updates](https://twitter.com/formtastic)
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far e
 ## Documentation & Support
 
 * [Documentation is available on rdoc.info](https://rdoc.info/projects/justinfrench/formtastic)
-* [We track issues & bugs on GitHub](https://github.com/justinfrench/formtastic/issues)
-* [We have a wiki on GitHub](https://github.com/justinfrench/formtastic/wiki)
+* [We track issues & bugs on GitHub](https://github.com/formtastic/formtastic/issues)
+* [We have a wiki on GitHub](https://github.com/formtastic/formtastic/wiki)
 * [StackOverflow can help](https://stackoverflow.com/questions/tagged/formtastic)
 * [Follow @formtastic on Twitter for news & updates](https://twitter.com/formtastic)
 
@@ -622,7 +622,7 @@ There are none other than Rails itself, but...
 
 Formtastic was created by [Justin French](https://www.justinfrench.com) with contributions from around 180 awesome developers. Run `git shortlog -n -s` to see the awesome.
 
-The project is hosted on Github: [https://github.com/justinfrench/formtastic](https://github.com/justinfrench/formtastic), where your contributions, forkings, comments, issues and feedback are greatly welcomed.
+The project is hosted on Github: [https://github.com/formtastic/formtastic](https://github.com/formtastic/formtastic), where your contributions, forkings, comments, issues and feedback are greatly welcomed.
 
 Copyright (c) 2007-2016 Justin French, released under the MIT license.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Formtastic
 
-[![Build Status](https://travis-ci.org/justinfrench/formtastic.svg?branch=master)](https://travis-ci.org/justinfrench/formtastic)
+[![Build Status](https://travis-ci.org/formtastic/formtastic.svg?branch=master)](https://travis-ci.org/formtastic/formtastic)
 [![Inline docs](https://inch-ci.org/github/justinfrench/formtastic.svg?branch=master)](https://inch-ci.org/github/justinfrench/formtastic)
 [![Code Climate](https://codeclimate.com/github/formtastic/formtastic/badges/gpa.svg)](https://codeclimate.com/github/formtastic/formtastic)
 [![Gem Version](https://badge.fury.io/rb/formtastic.svg)](https://badge.fury.io/rb/formtastic)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far e
 
 ## Documentation & Support
 
-* [Documentation is available on rdoc.info](https://rdoc.info/projects/justinfrench/formtastic)
+* [Documentation is available on rdoc.info](https://rdoc.info/projects/formtastic/formtastic)
 * [We track issues & bugs on GitHub](https://github.com/formtastic/formtastic/issues)
 * [We have a wiki on GitHub](https://github.com/formtastic/formtastic/wiki)
 * [StackOverflow can help](https://stackoverflow.com/questions/tagged/formtastic)

--- a/README.md
+++ b/README.md
@@ -623,5 +623,5 @@ Formtastic was created by [Justin French](https://www.justinfrench.com) with con
 
 The project is hosted on Github: [https://github.com/formtastic/formtastic](https://github.com/formtastic/formtastic), where your contributions, forkings, comments, issues and feedback are greatly welcomed.
 
-Copyright (c) 2007-2016 Justin French, released under the MIT license.
+Copyright (c) 2007-2020, released under the MIT license.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/justinfrench/formtastic.svg?branch=master)](https://travis-ci.org/justinfrench/formtastic)
 [![Inline docs](https://inch-ci.org/github/justinfrench/formtastic.svg?branch=master)](https://inch-ci.org/github/justinfrench/formtastic)
-[![Code Climate](https://codeclimate.com/github/justinfrench/formtastic/badges/gpa.svg)](https://codeclimate.com/github/justinfrench/formtastic)
+[![Code Climate](https://codeclimate.com/github/formtastic/formtastic/badges/gpa.svg)](https://codeclimate.com/github/formtastic/formtastic)
 [![Gem Version](https://badge.fury.io/rb/formtastic.svg)](https://badge.fury.io/rb/formtastic)
 
 Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far easier to create beautiful, semantically rich, syntactically awesome, readily stylable and wonderfully accessible HTML forms in your Rails applications.

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = [%q{Justin French}]
   s.email       = [%q{justin@indent.com.au}]
-  s.homepage    = %q{http://github.com/justinfrench/formtastic}
+  s.homepage    = %q{http://github.com/formtastic/formtastic}
   s.summary     = %q{A Rails form builder plugin/gem with semantically rich and accessible markup}
   s.description = %q{A Rails form builder plugin/gem with semantically rich and accessible markup}
   s.license     = 'MIT'

--- a/lib/generators/templates/formtastic.rb
+++ b/lib/generators/templates/formtastic.rb
@@ -91,7 +91,7 @@
 
 # By creating custom input class finder, you can change how input classes  are looked up.
 # For example you can make it to search for TextInputFilter instead of TextInput.
-# See https://github.com/justinfrench/formtastic/wiki/Custom-Class-Finders
+# See https://github.com/formtastic/formtastic/wiki/Custom-Class-Finders
 # Formtastic::FormBuilder.input_class_finder = Formtastic::InputClassFinder
 
 # Define custom namespaces in which to look up your Input classes. Default is
@@ -100,7 +100,7 @@
 
 # By creating custom action class finder, you can change how action classes are looked up.
 # For example you can make it to search for MyButtonAction instead of ButtonAction.
-# See https://github.com/justinfrench/formtastic/wiki/Custom-Class-Finders
+# See https://github.com/formtastic/formtastic/wiki/Custom-Class-Finders
 # Formtastic::FormBuilder.action_class_finder = Formtastic::ActionClassFinder
 
 # Define custom namespaces in which to look up your Action classes. Default is

--- a/sample/basic_inputs.html
+++ b/sample/basic_inputs.html
@@ -36,7 +36,7 @@
         <li class="input url stringish optional" id="gem_url_input">
           <label class="label" for="gem_url">URL</label>
           <input id="gem_url" name="gem[url]" type="url">
-          <p class="inline-hints">Example: https://github.com/justinfrench/formtastic</p>
+          <p class="inline-hints">Example: https://github.com/formtastic/formtastic</p>
         </li>
 
         <li class="input password stringish required" id="gem_password_input">

--- a/spec/builder/custom_builder_spec.rb
+++ b/spec/builder/custom_builder_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
         end
       end
 
-      # See: https://github.com/justinfrench/formtastic/issues/657
+      # See: https://github.com/formtastic/formtastic/issues/657
       it "should not conflict with navigasmic" do
         allow_any_instance_of(self.class).to receive(:builder).and_return('navigasmic')
 


### PR DESCRIPTION
This is just a bunch of copy changes. But in order to make each of these, I've set-up each linked service on the formtastic/formtastic URL instead of justinfrench/justinfrench.