### PR TITLE
Drop ruby 2.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,22 +24,12 @@ jobs:
           - gemfiles/rails_edge/Gemfile
 
         ruby:
-          - 2.4.10
           - 2.5.8
           - 2.6.6
           - 2.7.2
           - 3.0.0
 
         exclude:
-          - ruby: 2.4.10
-            gemfile: gemfiles/rails_6.0/Gemfile
-
-          - ruby: 2.4.10
-            gemfile: gemfiles/rails_6.1/Gemfile
-
-          - ruby: 2.4.10
-            gemfile: gemfiles/rails_edge/Gemfile
-
           - ruby: 2.5.8
             gemfile: gemfiles/rails_edge/Gemfile
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far e
 
 ## Compatibility
 
+* Formtastic master requires Rails 5.2 and Ruby 2.5 minimum
 * Formtastic 4 requires Rails 5.2 and Ruby 2.4 minimum
 * Formtastic 3 requires Rails 3.2.13 minimum
 * Formtastic 2 requires Rails 3

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.rubygems_version = %q{1.3.6}
 


### PR DESCRIPTION
It reached it's End of Life in Abril 2020:
https://www.ruby-lang.org/es/news/2020/04/05/support-of-ruby-2-4-has-ended/.