### PR TITLE
Determine NamespacedClassFinder#finder method after rails config

### DIFF
--- a/lib/formtastic/namespaced_class_finder.rb
+++ b/lib/formtastic/namespaced_class_finder.rb
@@ -32,6 +32,10 @@ module Formtastic
       defined?(Rails) && ::Rails.application && ::Rails.application.config.respond_to?(:eager_load) && ::Rails.application.config.eager_load
     end
 
+    def self.finder_method
+      @finder_method ||= use_const_defined? ? :find_with_const_defined : :find_by_trying
+    end
+
     # @param namespaces [Array<Module>]
     def initialize(namespaces)
       @namespaces = namespaces.flatten
@@ -68,10 +72,6 @@ module Formtastic
 
     def finder(class_name) # @private
       send(self.class.finder_method, class_name)
-    end
-
-    def self.finder_method
-      @finder_method ||= use_const_defined? ? :find_with_const_defined : :find_by_trying
     end
 
     # Looks up the given class name in the configured namespaces in order,

--- a/lib/formtastic/namespaced_class_finder.rb
+++ b/lib/formtastic/namespaced_class_finder.rb
@@ -66,14 +66,12 @@ module Formtastic
 
     private
 
-    if use_const_defined?
-      def finder(class_name) # @private
-        find_with_const_defined(class_name)
-      end
-    else
-      def finder(class_name) # @private
-        find_by_trying(class_name)
-      end
+    def finder(class_name) # @private
+      send(self.class.finder_method, class_name)
+    end
+
+    def self.finder_method
+      @finder_method ||= use_const_defined? ? :find_with_const_defined : :find_by_trying
     end
 
     # Looks up the given class name in the configured namespaces in order,

--- a/spec/namespaced_class_finder_spec.rb
+++ b/spec/namespaced_class_finder_spec.rb
@@ -54,16 +54,16 @@ RSpec.describe Formtastic::NamespacedClassFinder do
 
   context '#finder' do
     before do
-      allow(Rails.application.config).to receive(:cache_classes).and_return(cache_classes)
+      allow(Rails.application.config).to receive(:eager_load).and_return(eager_load)
     end
 
-    context 'when cache_classes is on' do
-      let(:cache_classes) { true }
+    context 'when eager_load is on' do
+      let(:eager_load) { true }
       it_behaves_like 'Namespaced Class Finder'
     end
 
-    context 'when cache_classes is off' do
-      let(:cache_classes) { false }
+    context 'when eager_load is off' do
+      let(:eager_load) { false }
       it_behaves_like 'Namespaced Class Finder'
     end
   end

--- a/spec/namespaced_class_finder_spec.rb
+++ b/spec/namespaced_class_finder_spec.rb
@@ -59,11 +59,22 @@ RSpec.describe Formtastic::NamespacedClassFinder do
 
     context 'when eager_load is on' do
       let(:eager_load) { true }
+
+      it "finder_method is :find_with_const_defined" do
+        expect(described_class.finder_method).to eq(:find_with_const_defined)
+      end
+
       it_behaves_like 'Namespaced Class Finder'
     end
 
     context 'when eager_load is off' do
       let(:eager_load) { false }
+
+      it "finder_method is :find_by_trying" do
+        described_class.instance_variable_set(:@finder_method, nil) # clear cache
+        expect(described_class.finder_method).to eq(:find_by_trying)
+      end
+
       it_behaves_like 'Namespaced Class Finder'
     end
   end


### PR DESCRIPTION
Hi there!

You're making a great gem, thank you very much.

I've found a bug while profiling a thing in our app.

Formtastic has two modes of finding classes, one is fast and another fetches new files in development. It works in dev mode all the time because `use_const_defined?` is called when `Rails.application` is still nil.

As a result, finding input classes sometimes takes half of the time Formtastic works.

This PR fixes this by determining the finder method on the first calling, which likely happens after the app initialization.

Bonus: spec for the class tested changed `cache_classes` config value, which, I suppose, was used before `eager_load`.

Testing
-------

I don't know how to make a spec for the case, but here is how I do it manually:
1. `config.eager_load = !!ENV["EAGER_LOAD"] # config/environments/development.rb`
2. `EAGER_LOAD=true rails c`
3. For master: 
```
show-source Formtastic::NamespacedClassFinder#finder # for pry
Formtastic::NamespacedClassFinder.new([]).method(:finder).source_location # would work everywhere
```
For this PR:
```
Formtastic::NamespacedClassFinder.send(:finder_method)
```

Workaround
------------

Just in case the fix won't get to master or will be released only for v4. I've added a workaround to reach the same effect
```
# config/initializers/formtastic_namespaced_class_finder_patch.rb
if Rails.configuration.eager_load
  class Formtastic::NamespacedClassFinder
    private
      def finder(class_name)
        find_with_const_defined(class_name)
      end
  end
end
```