### PR TITLE
Use SafeBuffer to better mimic Rails in tests

### DIFF
--- a/spec/actions/button_action_spec.rb
+++ b/spec/actions/button_action_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'ButtonAction', 'when submitting' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -25,7 +25,7 @@ RSpec.describe 'ButtonAction', 'when resetting' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -48,7 +48,7 @@ RSpec.describe 'InputAction', 'when cancelling' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   

--- a/spec/actions/generic_action_spec.rb
+++ b/spec/actions/generic_action_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'InputAction::Base' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -484,7 +484,7 @@ RSpec.describe 'InputAction::Base' do
   describe 'when the model is two words' do
 
     before do
-      output_buffer = ''
+      output_buffer = ActiveSupport::SafeBuffer.new ''
       class ::UserPost
         extend ActiveModel::Naming if defined?(ActiveModel::Naming)
         include ActiveModel::Conversion if defined?(ActiveModel::Conversion)

--- a/spec/actions/input_action_spec.rb
+++ b/spec/actions/input_action_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'InputAction', 'when submitting' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -25,7 +25,7 @@ RSpec.describe 'InputAction', 'when resetting' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -44,7 +44,7 @@ RSpec.describe 'InputAction', 'when cancelling' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   

--- a/spec/actions/link_action_spec.rb
+++ b/spec/actions/link_action_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'LinkAction', 'when cancelling' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -58,7 +58,7 @@ RSpec.describe 'LinkAction', 'when submitting' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -77,7 +77,7 @@ RSpec.describe 'LinkAction', 'when submitting' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   

--- a/spec/builder/custom_builder_spec.rb
+++ b/spec/builder/custom_builder_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
   end
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/builder/error_proc_spec.rb
+++ b/spec/builder/error_proc_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Rails field_error_proc' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/builder/semantic_fields_for_spec.rb
+++ b/spec/builder/semantic_fields_for_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#fields_for' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     allow(@new_post).to receive(:author).and_return(::Author.new)
   end

--- a/spec/generators/formtastic/form/form_generator_spec.rb
+++ b/spec/generators/formtastic/form/form_generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Formtastic::FormGenerator do
   destination File.expand_path("../../../../../tmp", __FILE__)
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     prepare_destination
     mock_everything
     allow(::Post).to receive(:reflect_on_all_associations).with(:belongs_to).and_return([

--- a/spec/helpers/actions_helper_spec.rb
+++ b/spec/helpers/actions_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#actions' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'FormHelper' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/helpers/inputs_helper_spec.rb
+++ b/spec/helpers/inputs_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -171,8 +171,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
             builder.inputs(:for => [:author, @bob]) do
               #
             end
-          }.to raise_error(ArgumentError, 'You gave :for option with a block to inputs method, ' <<
-                                              'but the block does not accept any argument.')
+          }.to raise_error(ArgumentError, 'You gave :for option with a block to inputs method, but the block does not accept any argument.')
         end
       end
   
@@ -401,7 +400,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
 
       context "with non-standard foregin keys" do
         before do
-          @output_buffer = ''
+          @output_buffer = ActiveSupport::SafeBuffer.new ''
         end
 
         it 'should respect foreign key while rendering select' do

--- a/spec/helpers/reflection_helper_spec.rb
+++ b/spec/helpers/reflection_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::Helpers::Reflection' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/helpers/semantic_errors_helper_spec.rb
+++ b/spec/helpers/semantic_errors_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     @title_errors = ['must not be blank', 'must be awesome']
     @base_errors = ['base error message', 'nasty error']

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Formtastic::I18n' do
     include FormtasticSpecHelper
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       ::I18n.backend.store_translations :en, {:formtastic => {

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'boolean input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -208,7 +208,7 @@ RSpec.describe 'boolean input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => "context2") do |builder|
@@ -224,7 +224,7 @@ RSpec.describe 'boolean input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe 'check_boxes input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
   describe 'for a has_many association' do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@fred) do |builder|
@@ -169,7 +169,7 @@ RSpec.describe 'check_boxes input' do
 
     describe 'when :hidden_fields is set to false' do
       before do
-        @output_buffer = ''
+        @output_buffer = ActiveSupport::SafeBuffer.new ''
         mock_everything
 
         concat(semantic_form_for(@fred) do |builder|
@@ -196,7 +196,7 @@ RSpec.describe 'check_boxes input' do
 
     describe 'when :disabled is set' do
       before do
-        @output_buffer = ''
+        @output_buffer = ActiveSupport::SafeBuffer.new ''
       end
 
       describe "no disabled items" do
@@ -286,7 +286,7 @@ RSpec.describe 'check_boxes input' do
 
     describe "when :label option is false" do
       before do
-        @output_buffer = ''
+        @output_buffer = ActiveSupport::SafeBuffer.new ''
         allow(@new_post).to receive(:author_ids).and_return(nil)
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:authors, :as => :check_boxes, :label => false))
@@ -337,7 +337,7 @@ RSpec.describe 'check_boxes input' do
   describe 'for a has_and_belongs_to_many association' do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@freds_post) do |builder|
@@ -362,7 +362,7 @@ RSpec.describe 'check_boxes input' do
   describe ':collection for a has_and_belongs_to_many association' do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@freds_post) do |builder|
@@ -387,7 +387,7 @@ RSpec.describe 'check_boxes input' do
   describe 'for an association when a :collection is provided' do
     describe 'it should use the specified :member_value option' do
       before do
-        @output_buffer = ''
+        @output_buffer = ActiveSupport::SafeBuffer.new ''
         mock_everything
       end
 
@@ -410,7 +410,7 @@ RSpec.describe 'check_boxes input' do
 
   describe 'when :collection is provided as an array of arrays' do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
       allow(@fred).to receive(:genres) { ['fiction', 'biography'] }
 
@@ -427,7 +427,7 @@ RSpec.describe 'check_boxes input' do
 
   describe 'when :collection is a set' do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
       allow(@fred).to receive(:roles) { Set.new([:reviewer, :admin]) }
 
@@ -446,7 +446,7 @@ RSpec.describe 'check_boxes input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@fred, :namespace => "context2") do |builder|
@@ -465,7 +465,7 @@ RSpec.describe 'check_boxes input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@fred) do |builder|
@@ -492,7 +492,7 @@ RSpec.describe 'check_boxes input' do
 
   describe "when collection is an array" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       @_collection = [["First", 1], ["Second", 2]]
       mock_everything
 

--- a/spec/inputs/color_input_spec.rb
+++ b/spec/inputs/color_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'color input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'color input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/country_input_spec.rb
+++ b/spec/inputs/country_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'country input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -80,7 +80,7 @@ RSpec.describe 'country input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|

--- a/spec/inputs/datalist_input_spec.rb
+++ b/spec/inputs/datalist_input_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "datalist inputs" do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/date_picker_input_spec.rb
+++ b/spec/inputs/date_picker_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'date_picker input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -412,7 +412,7 @@ RSpec.describe 'date_picker input' do
   
   describe "when index is provided" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/date_select_input_spec.rb
+++ b/spec/inputs/date_select_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'date select input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -74,7 +74,7 @@ RSpec.describe 'date select input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/datetime_picker_input_spec.rb
+++ b/spec/inputs/datetime_picker_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'datetime_picker input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -453,7 +453,7 @@ RSpec.describe 'datetime_picker input' do
   
   describe "when index is provided" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/datetime_select_input_spec.rb
+++ b/spec/inputs/datetime_select_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'datetime select input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -79,7 +79,7 @@ RSpec.describe 'datetime select input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/email_input_spec.rb
+++ b/spec/inputs/email_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'email input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'email input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/file_input_spec.rb
+++ b/spec/inputs/file_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'file input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     concat(semantic_form_for(@new_post) do |builder|
@@ -33,7 +33,7 @@ RSpec.describe 'file input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
@@ -49,7 +49,7 @@ RSpec.describe 'file input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/hidden_input_spec.rb
+++ b/spec/inputs/hidden_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'hidden input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -64,7 +64,7 @@ RSpec.describe 'hidden input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
       
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
@@ -88,7 +88,7 @@ RSpec.describe 'hidden input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/include_blank_spec.rb
+++ b/spec/inputs/include_blank_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "*select: options[:include_blank]" do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     allow(@new_post).to receive(:author_id).and_return(nil)

--- a/spec/inputs/label_spec.rb
+++ b/spec/inputs/label_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/number_input_spec.rb
+++ b/spec/inputs/number_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'number input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     allow(@new_post.class).to receive(:validators_on).with(:title).and_return([
@@ -71,7 +71,7 @@ RSpec.describe 'number input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/password_input_spec.rb
+++ b/spec/inputs/password_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'password input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     concat(semantic_form_for(@new_post) do |builder|
@@ -60,7 +60,7 @@ RSpec.describe 'password input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/phone_input_spec.rb
+++ b/spec/inputs/phone_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'phone input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'phone input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/placeholder_spec.rb
+++ b/spec/inputs/placeholder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'string input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'radio input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -216,7 +216,7 @@ RSpec.describe 'radio input' do
 
   describe "when :label option is false" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       allow(@new_post).to receive(:author_ids).and_return(nil)
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.input(:authors, :as => :radio, :label => false))
@@ -248,7 +248,7 @@ RSpec.describe 'radio input' do
 
   describe "when :namespace is given on form" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       allow(@new_post).to receive(:author_ids).and_return(nil)
       concat(semantic_form_for(@new_post, :namespace => "custom_prefix") do |builder|
         concat(builder.input(:authors, :as => :radio, :label => ''))
@@ -263,7 +263,7 @@ RSpec.describe 'radio input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
@@ -290,7 +290,7 @@ RSpec.describe 'radio input' do
 
   describe "when collection contains integers" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(:project) do |builder|
@@ -307,7 +307,7 @@ RSpec.describe 'radio input' do
 
   describe "when collection contains symbols" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(:project) do |builder|

--- a/spec/inputs/range_input_spec.rb
+++ b/spec/inputs/range_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'range input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -46,7 +46,7 @@ RSpec.describe 'range input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/readonly_spec.rb
+++ b/spec/inputs/readonly_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'readonly option' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/search_input_spec.rb
+++ b/spec/inputs/search_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'search input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'search input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'select input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -522,7 +522,7 @@ RSpec.describe 'select input' do
 
   describe "enum" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       @some_meta_descriptions = ["One", "Two", "Three"]
       allow(@new_post).to receive(:meta_description).at_least(:once)
     end
@@ -573,7 +573,7 @@ RSpec.describe 'select input' do
   describe "when index is provided" do
   
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
   
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'string input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -179,7 +179,7 @@ RSpec.describe 'string input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/text_input_spec.rb
+++ b/spec/inputs/text_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'text input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     concat(semantic_form_for(@new_post) do |builder|
@@ -67,7 +67,7 @@ RSpec.describe 'text input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
@@ -84,7 +84,7 @@ RSpec.describe 'text input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/time_picker_input_spec.rb
+++ b/spec/inputs/time_picker_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'time_picker input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -418,7 +418,7 @@ RSpec.describe 'time_picker input' do
   
   describe "when index is provided" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/time_select_input_spec.rb
+++ b/spec/inputs/time_select_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'time select input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/time_zone_input_spec.rb
+++ b/spec/inputs/time_zone_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'time_zone input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     concat(semantic_form_for(@new_post) do |builder|
@@ -41,7 +41,7 @@ RSpec.describe 'time_zone input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
@@ -58,7 +58,7 @@ RSpec.describe 'time_zone input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/url_input_spec.rb
+++ b/spec/inputs/url_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'url input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'url input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/with_options_spec.rb
+++ b/spec/inputs/with_options_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'string input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -2,7 +2,7 @@ RSpec.shared_context 'form builder' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 


### PR DESCRIPTION
Small, mostly inconsequential change but makes the tests a bit more accurate in replicating what `output_buffer` looks like.