### PR TITLE
Avoid mutating string literals

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    formtastic (4.0.0.rc1)
+    formtastic (4.0.0)
       actionpack (>= 5.2.0)
 
 GEM

--- a/lib/formtastic.rb
+++ b/lib/formtastic.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'formtastic/engine' if defined?(::Rails)
 
 module Formtastic

--- a/lib/formtastic/action_class_finder.rb
+++ b/lib/formtastic/action_class_finder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
 
   # Uses the {NamespacedClassFinder} to look up action class names.

--- a/lib/formtastic/actions.rb
+++ b/lib/formtastic/actions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Actions
     extend ActiveSupport::Autoload

--- a/lib/formtastic/actions/base.rb
+++ b/lib/formtastic/actions/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Actions
     module Base

--- a/lib/formtastic/actions/button_action.rb
+++ b/lib/formtastic/actions/button_action.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Actions
 

--- a/lib/formtastic/actions/buttonish.rb
+++ b/lib/formtastic/actions/buttonish.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Actions
     module Buttonish

--- a/lib/formtastic/actions/input_action.rb
+++ b/lib/formtastic/actions/input_action.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Actions
 

--- a/lib/formtastic/actions/link_action.rb
+++ b/lib/formtastic/actions/link_action.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Actions
   # Outputs a link wrapped in the standard `<li>` wrapper. This the default for `:cancel` actions.

--- a/lib/formtastic/deprecation.rb
+++ b/lib/formtastic/deprecation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support/deprecation'
 
 module Formtastic

--- a/lib/formtastic/engine.rb
+++ b/lib/formtastic/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   # Required for formtastic.css to be discoverable in the asset pipeline
   # @private

--- a/lib/formtastic/form_builder.rb
+++ b/lib/formtastic/form_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   class FormBuilder < ActionView::Helpers::FormBuilder
 

--- a/lib/formtastic/helpers.rb
+++ b/lib/formtastic/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
     autoload :ButtonsHelper, 'formtastic/helpers/buttons_helper'

--- a/lib/formtastic/helpers/action_helper.rb
+++ b/lib/formtastic/helpers/action_helper.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Formtastic
   module Helpers
     module ActionHelper

--- a/lib/formtastic/helpers/actions_helper.rb
+++ b/lib/formtastic/helpers/actions_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
     # ActionsHelper encapsulates the responsibilties of the {#actions} DSL for acting on 

--- a/lib/formtastic/helpers/enum.rb
+++ b/lib/formtastic/helpers/enum.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
     # @private

--- a/lib/formtastic/helpers/errors_helper.rb
+++ b/lib/formtastic/helpers/errors_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
     module ErrorsHelper

--- a/lib/formtastic/helpers/fieldset_wrapper.rb
+++ b/lib/formtastic/helpers/fieldset_wrapper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
     # @private

--- a/lib/formtastic/helpers/fieldset_wrapper.rb
+++ b/lib/formtastic/helpers/fieldset_wrapper.rb
@@ -42,7 +42,7 @@ module Formtastic
 
         legend = field_set_legend(html_options)
         fieldset = template.content_tag(:fieldset,
-          legend.html_safe << template.content_tag(:ol, contents.html_safe),
+          legend.html_safe + template.content_tag(:ol, contents.html_safe),
           html_options.except(:builder, :parent, :name)
         )
 

--- a/lib/formtastic/helpers/fieldset_wrapper.rb
+++ b/lib/formtastic/helpers/fieldset_wrapper.rb
@@ -42,7 +42,7 @@ module Formtastic
 
         legend = field_set_legend(html_options)
         fieldset = template.content_tag(:fieldset,
-          legend.html_safe + template.content_tag(:ol, contents.html_safe),
+          legend.html_safe << template.content_tag(:ol, contents.html_safe),
           html_options.except(:builder, :parent, :name)
         )
 

--- a/lib/formtastic/helpers/file_column_detection.rb
+++ b/lib/formtastic/helpers/file_column_detection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
     # @private

--- a/lib/formtastic/helpers/form_helper.rb
+++ b/lib/formtastic/helpers/form_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
 

--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 module Formtastic
   module Helpers
 

--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
 

--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -378,7 +378,8 @@ module Formtastic
         args << options.merge!(:parent => { :builder => self, :for => options[:for] })
 
         fields_for_block = if block_given?
-          raise ArgumentError, 'You gave :for option with a block to inputs method, but the block does not accept any argument.' if block.arity <= 0
+          raise ArgumentError, 'You gave :for option with a block to inputs method, ' <<
+                               'but the block does not accept any argument.' if block.arity <= 0
           lambda do |f|
             contents = f.inputs(*args) do
               if block.arity == 1  # for backwards compatibility with REE & Ruby 1.8.x

--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -378,7 +378,7 @@ module Formtastic
         args << options.merge!(:parent => { :builder => self, :for => options[:for] })
 
         fields_for_block = if block_given?
-          raise ArgumentError, 'You gave :for option with a block to inputs method, ' <<
+          raise ArgumentError, 'You gave :for option with a block to inputs method, ' +
                                'but the block does not accept any argument.' if block.arity <= 0
           lambda do |f|
             contents = f.inputs(*args) do

--- a/lib/formtastic/helpers/inputs_helper.rb
+++ b/lib/formtastic/helpers/inputs_helper.rb
@@ -378,8 +378,7 @@ module Formtastic
         args << options.merge!(:parent => { :builder => self, :for => options[:for] })
 
         fields_for_block = if block_given?
-          raise ArgumentError, 'You gave :for option with a block to inputs method, ' <<
-                               'but the block does not accept any argument.' if block.arity <= 0
+          raise ArgumentError, 'You gave :for option with a block to inputs method, but the block does not accept any argument.' if block.arity <= 0
           lambda do |f|
             contents = f.inputs(*args) do
               if block.arity == 1  # for backwards compatibility with REE & Ruby 1.8.x

--- a/lib/formtastic/helpers/reflection.rb
+++ b/lib/formtastic/helpers/reflection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Helpers
     # @private

--- a/lib/formtastic/html_attributes.rb
+++ b/lib/formtastic/html_attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   # @private
   module HtmlAttributes

--- a/lib/formtastic/i18n.rb
+++ b/lib/formtastic/i18n.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module Formtastic
   # @private

--- a/lib/formtastic/input_class_finder.rb
+++ b/lib/formtastic/input_class_finder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
 
   # Uses the {Formtastic::NamespacedClassFinder} to look up input class names.

--- a/lib/formtastic/inputs.rb
+++ b/lib/formtastic/inputs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     extend ActiveSupport::Autoload

--- a/lib/formtastic/inputs/base.rb
+++ b/lib/formtastic/inputs/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/associations.rb
+++ b/lib/formtastic/inputs/base/associations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/choices.rb
+++ b/lib/formtastic/inputs/base/choices.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/choices.rb
+++ b/lib/formtastic/inputs/base/choices.rb
@@ -93,7 +93,7 @@ module Formtastic
               label_html_options.merge(:class => "label")
             )
           else
-            "".html_safe
+            +"".html_safe
           end
         end
 

--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/database.rb
+++ b/lib/formtastic/inputs/base/database.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/datetime_pickerish.rb
+++ b/lib/formtastic/inputs/base/datetime_pickerish.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/errors.rb
+++ b/lib/formtastic/inputs/base/errors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/errors.rb
+++ b/lib/formtastic/inputs/base/errors.rb
@@ -5,7 +5,7 @@ module Formtastic
       module Errors
         
         def error_html
-          errors? ? send(:"error_#{builder.inline_errors}_html") : ""
+          errors? ? send(:"error_#{builder.inline_errors}_html") : +""
         end
         
         def error_sentence_html
@@ -28,7 +28,7 @@ module Formtastic
         end
         
         def error_none_html
-          ""
+          +""
         end
         
         def errors?

--- a/lib/formtastic/inputs/base/fileish.rb
+++ b/lib/formtastic/inputs/base/fileish.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/hints.rb
+++ b/lib/formtastic/inputs/base/hints.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/html.rb
+++ b/lib/formtastic/inputs/base/html.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/html.rb
+++ b/lib/formtastic/inputs/base/html.rb
@@ -44,7 +44,7 @@ module Formtastic
             # TODO there's no coverage for this case, not sure how to create a scenario for it
             builder.auto_index
           else
-            ""
+            +""
           end
         end
 

--- a/lib/formtastic/inputs/base/labelling.rb
+++ b/lib/formtastic/inputs/base/labelling.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/labelling.rb
+++ b/lib/formtastic/inputs/base/labelling.rb
@@ -7,7 +7,7 @@ module Formtastic
         include Formtastic::LocalizedString
         
         def label_html
-          render_label? ? builder.label(input_name, label_text, label_html_options) : "".html_safe
+          render_label? ? builder.label(input_name, label_text, label_html_options) : +"".html_safe
         end
         
         def label_html_options

--- a/lib/formtastic/inputs/base/naming.rb
+++ b/lib/formtastic/inputs/base/naming.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/numeric.rb
+++ b/lib/formtastic/inputs/base/numeric.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/options.rb
+++ b/lib/formtastic/inputs/base/options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/placeholder.rb
+++ b/lib/formtastic/inputs/base/placeholder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/stringish.rb
+++ b/lib/formtastic/inputs/base/stringish.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/stringish.rb
+++ b/lib/formtastic/inputs/base/stringish.rb
@@ -7,7 +7,7 @@ module Formtastic
         # @abstract Override this method in your input class to describe how the input should render itself.
         def to_html
           input_wrapping do
-            label_html +
+            label_html <<
             builder.text_field(method, input_html_options)
           end
         end

--- a/lib/formtastic/inputs/base/stringish.rb
+++ b/lib/formtastic/inputs/base/stringish.rb
@@ -7,7 +7,7 @@ module Formtastic
         # @abstract Override this method in your input class to describe how the input should render itself.
         def to_html
           input_wrapping do
-            label_html <<
+            label_html +
             builder.text_field(method, input_html_options)
           end
         end

--- a/lib/formtastic/inputs/base/timeish.rb
+++ b/lib/formtastic/inputs/base/timeish.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/timeish.rb
+++ b/lib/formtastic/inputs/base/timeish.rb
@@ -97,13 +97,10 @@ module Formtastic
         def to_html
           input_wrapping do
             fragments_wrapping do
-              hidden_fragments <<
-              fragments_label <<
-              template.content_tag(:ol,
+              hidden_fragments + fragments_label + template.content_tag(:ol,
                 fragments.map do |fragment|
                   fragment_wrapping do
-                    fragment_label_html(fragment) <<
-                    fragment_input_html(fragment)
+                    fragment_label_html(fragment) + fragment_input_html(fragment)
                   end
                 end.join.html_safe, # TODO is this safe?
                 { :class => 'fragments-group' } # TODO refactor to fragments_group_wrapping

--- a/lib/formtastic/inputs/base/timeish.rb
+++ b/lib/formtastic/inputs/base/timeish.rb
@@ -157,7 +157,7 @@ module Formtastic
         
         def fragment_label_html(fragment)
           text = fragment_label(fragment)
-          text.blank? ? "".html_safe : template.content_tag(:label, text, :for => fragment_id(fragment))
+          text.blank? ? +"".html_safe : template.content_tag(:label, text, :for => fragment_id(fragment))
         end
         
         def value
@@ -218,7 +218,7 @@ module Formtastic
               :class => "label"
             )
           else
-            "".html_safe
+            +"".html_safe
           end
         end
         
@@ -229,7 +229,7 @@ module Formtastic
         end
         
         def hidden_fragments
-          "".html_safe
+          +"".html_safe
         end
         
         def hidden_field_name(fragment)

--- a/lib/formtastic/inputs/base/timeish.rb
+++ b/lib/formtastic/inputs/base/timeish.rb
@@ -97,10 +97,13 @@ module Formtastic
         def to_html
           input_wrapping do
             fragments_wrapping do
-              hidden_fragments + fragments_label + template.content_tag(:ol,
+              hidden_fragments <<
+              fragments_label <<
+              template.content_tag(:ol,
                 fragments.map do |fragment|
                   fragment_wrapping do
-                    fragment_label_html(fragment) + fragment_input_html(fragment)
+                    fragment_label_html(fragment) <<
+                    fragment_input_html(fragment)
                   end
                 end.join.html_safe, # TODO is this safe?
                 { :class => 'fragments-group' } # TODO refactor to fragments_group_wrapping

--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/base/wrapping.rb
+++ b/lib/formtastic/inputs/base/wrapping.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     module Base

--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -35,7 +35,8 @@ module Formtastic
 
       def to_html
         input_wrapping do
-          hidden_field_html + label_with_nested_checkbox
+          hidden_field_html <<
+          label_with_nested_checkbox
         end
       end
 
@@ -59,7 +60,7 @@ module Formtastic
       end
 
       def label_text_with_embedded_checkbox
-        check_box_html + "" + label_text
+        check_box_html << "" << label_text
       end
 
       def check_box_html

--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -60,7 +60,7 @@ module Formtastic
       end
 
       def label_text_with_embedded_checkbox
-        check_box_html << "" << label_text
+        check_box_html << +"" << label_text
       end
 
       def check_box_html

--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -35,8 +35,7 @@ module Formtastic
 
       def to_html
         input_wrapping do
-          hidden_field_html <<
-          label_with_nested_checkbox
+          hidden_field_html + label_with_nested_checkbox
         end
       end
 
@@ -60,7 +59,7 @@ module Formtastic
       end
 
       def label_text_with_embedded_checkbox
-        check_box_html << "" << label_text
+        check_box_html + "" + label_text
       end
 
       def check_box_html

--- a/lib/formtastic/inputs/boolean_input.rb
+++ b/lib/formtastic/inputs/boolean_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     # Boolean inputs are used to render an input for a single checkbox, typically for attributes

--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -101,7 +101,7 @@ module Formtastic
 
       def hidden_field_for_all
         if hidden_fields_for_every?
-          ''
+          +''
         else
           options = {}
           options[:class] = [method.to_s.singularize, 'default'].join('_') if value_as_class?

--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -78,9 +78,7 @@ module Formtastic
       def to_html
         input_wrapping do
           choices_wrapping do
-            legend_html <<
-            hidden_field_for_all <<
-            choices_group_wrapping do
+            legend_html + hidden_field_for_all + choices_group_wrapping do
               collection.map { |choice|
                 choice_wrapping(choice_wrapping_html_options(choice)) do
                   choice_html(choice)

--- a/lib/formtastic/inputs/check_boxes_input.rb
+++ b/lib/formtastic/inputs/check_boxes_input.rb
@@ -78,7 +78,9 @@ module Formtastic
       def to_html
         input_wrapping do
           choices_wrapping do
-            legend_html + hidden_field_for_all + choices_group_wrapping do
+            legend_html <<
+            hidden_field_for_all <<
+            choices_group_wrapping do
               collection.map { |choice|
                 choice_wrapping(choice_wrapping_html_options(choice)) do
                   choice_html(choice)

--- a/lib/formtastic/inputs/color_input.rb
+++ b/lib/formtastic/inputs/color_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/color_input.rb
+++ b/lib/formtastic/inputs/color_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.color_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/color_input.rb
+++ b/lib/formtastic/inputs/color_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.color_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/country_input.rb
+++ b/lib/formtastic/inputs/country_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     # Outputs a country select input, wrapping around a regular country_select helper.

--- a/lib/formtastic/inputs/country_input.rb
+++ b/lib/formtastic/inputs/country_input.rb
@@ -73,7 +73,7 @@ module Formtastic
       def to_html
         raise CountrySelectPluginMissing, "To use the :country input, please install a country_select plugin, like this one: https://github.com/stefanpenner/country_select" unless builder.respond_to?(:country_select)
         input_wrapping do
-          label_html <<
+          label_html +
           builder.country_select(method, priority_countries, input_options, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/country_input.rb
+++ b/lib/formtastic/inputs/country_input.rb
@@ -73,7 +73,7 @@ module Formtastic
       def to_html
         raise CountrySelectPluginMissing, "To use the :country input, please install a country_select plugin, like this one: https://github.com/stefanpenner/country_select" unless builder.respond_to?(:country_select)
         input_wrapping do
-          label_html +
+          label_html <<
           builder.country_select(method, priority_countries, input_options, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/datalist_input.rb
+++ b/lib/formtastic/inputs/datalist_input.rb
@@ -19,9 +19,9 @@ module Formtastic
       def to_html
         @name = input_html_options[:id].gsub(/_id$/, "")
         input_wrapping do
-          # standard input
-          # append new datalist element
-          label_html + builder.text_field(method, input_html_options) + data_list_html
+          label_html <<
+          builder.text_field(method, input_html_options) << # standard input
+          data_list_html # append new datalist element
         end
       end
 

--- a/lib/formtastic/inputs/datalist_input.rb
+++ b/lib/formtastic/inputs/datalist_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     # Outputs a label and a text field, along with a datalist tag

--- a/lib/formtastic/inputs/datalist_input.rb
+++ b/lib/formtastic/inputs/datalist_input.rb
@@ -19,9 +19,9 @@ module Formtastic
       def to_html
         @name = input_html_options[:id].gsub(/_id$/, "")
         input_wrapping do
-          label_html <<
-          builder.text_field(method, input_html_options) << # standard input
-          data_list_html # append new datalist element
+          # standard input
+          # append new datalist element
+          label_html + builder.text_field(method, input_html_options) + data_list_html
         end
       end
 

--- a/lib/formtastic/inputs/date_picker_input.rb
+++ b/lib/formtastic/inputs/date_picker_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     

--- a/lib/formtastic/inputs/date_select_input.rb
+++ b/lib/formtastic/inputs/date_select_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     # Outputs a series of select boxes for the fragments that make up a date (year, month, day).

--- a/lib/formtastic/inputs/datetime_picker_input.rb
+++ b/lib/formtastic/inputs/datetime_picker_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     

--- a/lib/formtastic/inputs/datetime_select_input.rb
+++ b/lib/formtastic/inputs/datetime_select_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/email_input.rb
+++ b/lib/formtastic/inputs/email_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/email_input.rb
+++ b/lib/formtastic/inputs/email_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.email_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/email_input.rb
+++ b/lib/formtastic/inputs/email_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.email_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/file_input.rb
+++ b/lib/formtastic/inputs/file_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/file_input.rb
+++ b/lib/formtastic/inputs/file_input.rb
@@ -34,7 +34,7 @@ module Formtastic
       include Base
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.file_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/file_input.rb
+++ b/lib/formtastic/inputs/file_input.rb
@@ -34,7 +34,7 @@ module Formtastic
       include Base
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.file_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/hidden_input.rb
+++ b/lib/formtastic/inputs/hidden_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/hidden_input.rb
+++ b/lib/formtastic/inputs/hidden_input.rb
@@ -43,7 +43,7 @@ module Formtastic
       end
       
       def error_html
-        ""
+        +""
       end
       
       def errors?
@@ -51,7 +51,7 @@ module Formtastic
       end
       
       def hint_html
-        ""
+        +""
       end
       
       def hint?

--- a/lib/formtastic/inputs/number_input.rb
+++ b/lib/formtastic/inputs/number_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/number_input.rb
+++ b/lib/formtastic/inputs/number_input.rb
@@ -75,7 +75,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.number_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/number_input.rb
+++ b/lib/formtastic/inputs/number_input.rb
@@ -75,7 +75,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.number_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/password_input.rb
+++ b/lib/formtastic/inputs/password_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/password_input.rb
+++ b/lib/formtastic/inputs/password_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.password_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/password_input.rb
+++ b/lib/formtastic/inputs/password_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.password_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/phone_input.rb
+++ b/lib/formtastic/inputs/phone_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/phone_input.rb
+++ b/lib/formtastic/inputs/phone_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.phone_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/phone_input.rb
+++ b/lib/formtastic/inputs/phone_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.phone_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/radio_input.rb
+++ b/lib/formtastic/inputs/radio_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/radio_input.rb
+++ b/lib/formtastic/inputs/radio_input.rb
@@ -133,7 +133,7 @@ module Formtastic
       def to_html
         input_wrapping do
           choices_wrapping do
-            legend_html +
+            legend_html <<
             choices_group_wrapping do
               collection.map { |choice| 
                 choice_wrapping(choice_wrapping_html_options(choice)) do
@@ -147,7 +147,7 @@ module Formtastic
 
       def choice_html(choice)        
         template.content_tag(:label,
-          builder.radio_button(input_name, choice_value(choice), input_html_options.merge(choice_html_options(choice)).merge(:required => false)) +
+          builder.radio_button(input_name, choice_value(choice), input_html_options.merge(choice_html_options(choice)).merge(:required => false)) << 
           choice_label(choice),
           label_html_options.merge(:for => choice_input_dom_id(choice), :class => nil)
         )

--- a/lib/formtastic/inputs/radio_input.rb
+++ b/lib/formtastic/inputs/radio_input.rb
@@ -133,7 +133,7 @@ module Formtastic
       def to_html
         input_wrapping do
           choices_wrapping do
-            legend_html <<
+            legend_html +
             choices_group_wrapping do
               collection.map { |choice| 
                 choice_wrapping(choice_wrapping_html_options(choice)) do
@@ -147,7 +147,7 @@ module Formtastic
 
       def choice_html(choice)        
         template.content_tag(:label,
-          builder.radio_button(input_name, choice_value(choice), input_html_options.merge(choice_html_options(choice)).merge(:required => false)) << 
+          builder.radio_button(input_name, choice_value(choice), input_html_options.merge(choice_html_options(choice)).merge(:required => false)) +
           choice_label(choice),
           label_html_options.merge(:for => choice_input_dom_id(choice), :class => nil)
         )

--- a/lib/formtastic/inputs/range_input.rb
+++ b/lib/formtastic/inputs/range_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     

--- a/lib/formtastic/inputs/range_input.rb
+++ b/lib/formtastic/inputs/range_input.rb
@@ -74,7 +74,7 @@ module Formtastic
 
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.range_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/range_input.rb
+++ b/lib/formtastic/inputs/range_input.rb
@@ -74,7 +74,7 @@ module Formtastic
 
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.range_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/search_input.rb
+++ b/lib/formtastic/inputs/search_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/search_input.rb
+++ b/lib/formtastic/inputs/search_input.rb
@@ -32,7 +32,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.search_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/search_input.rb
+++ b/lib/formtastic/inputs/search_input.rb
@@ -32,7 +32,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.search_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/select_input.rb
+++ b/lib/formtastic/inputs/select_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     # A select input is used to render a `<select>` tag with a series of options to choose from.

--- a/lib/formtastic/inputs/select_input.rb
+++ b/lib/formtastic/inputs/select_input.rb
@@ -165,7 +165,7 @@ module Formtastic
 
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           select_html
         end
       end

--- a/lib/formtastic/inputs/select_input.rb
+++ b/lib/formtastic/inputs/select_input.rb
@@ -165,7 +165,7 @@ module Formtastic
 
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           select_html
         end
       end

--- a/lib/formtastic/inputs/string_input.rb
+++ b/lib/formtastic/inputs/string_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/text_input.rb
+++ b/lib/formtastic/inputs/text_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/text_input.rb
+++ b/lib/formtastic/inputs/text_input.rb
@@ -39,7 +39,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.text_area(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/text_input.rb
+++ b/lib/formtastic/inputs/text_input.rb
@@ -39,7 +39,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.text_area(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/time_picker_input.rb
+++ b/lib/formtastic/inputs/time_picker_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     

--- a/lib/formtastic/inputs/time_select_input.rb
+++ b/lib/formtastic/inputs/time_select_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
     # Outputs a series of select boxes for the fragments that make up a time (hour, minute, second).

--- a/lib/formtastic/inputs/time_zone_input.rb
+++ b/lib/formtastic/inputs/time_zone_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/time_zone_input.rb
+++ b/lib/formtastic/inputs/time_zone_input.rb
@@ -46,7 +46,8 @@ module Formtastic
 
       def to_html
         input_wrapping do
-          label_html + builder.time_zone_select(method, priority_zones, input_options, input_html_options)
+          label_html <<
+          builder.time_zone_select(method, priority_zones, input_options, input_html_options)
         end
       end
 

--- a/lib/formtastic/inputs/time_zone_input.rb
+++ b/lib/formtastic/inputs/time_zone_input.rb
@@ -46,8 +46,7 @@ module Formtastic
 
       def to_html
         input_wrapping do
-          label_html <<
-          builder.time_zone_select(method, priority_zones, input_options, input_html_options)
+          label_html + builder.time_zone_select(method, priority_zones, input_options, input_html_options)
         end
       end
 

--- a/lib/formtastic/inputs/url_input.rb
+++ b/lib/formtastic/inputs/url_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module Inputs
 

--- a/lib/formtastic/inputs/url_input.rb
+++ b/lib/formtastic/inputs/url_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html <<
+          label_html +
           builder.url_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/inputs/url_input.rb
+++ b/lib/formtastic/inputs/url_input.rb
@@ -33,7 +33,7 @@ module Formtastic
       
       def to_html
         input_wrapping do
-          label_html +
+          label_html <<
           builder.url_field(method, input_html_options)
         end
       end

--- a/lib/formtastic/localized_string.rb
+++ b/lib/formtastic/localized_string.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   module LocalizedString
 

--- a/lib/formtastic/localizer.rb
+++ b/lib/formtastic/localizer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   # Implementation for looking up localized values within Formtastic using I18n, if no
   # explicit value (like the `:label` option) is set and I18n-lookups are enabled in the

--- a/lib/formtastic/namespaced_class_finder.rb
+++ b/lib/formtastic/namespaced_class_finder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   # This class implements class resolution in a namespace chain. It
   # is used both by Formtastic::Helpers::InputHelper and

--- a/lib/formtastic/version.rb
+++ b/lib/formtastic/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
   VERSION = "4.0.0"
 end

--- a/lib/generators/formtastic/form/form_generator.rb
+++ b/lib/generators/formtastic/form/form_generator.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 module Formtastic
   # Generates a Formtastic form partial based on an existing model. It will not overwrite existing
   # files without confirmation.

--- a/lib/generators/formtastic/input/input_generator.rb
+++ b/lib/generators/formtastic/input/input_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Formtastic
 
   # Modify existing inputs, subclass them, or create your own from scratch.

--- a/lib/generators/formtastic/install/install_generator.rb
+++ b/lib/generators/formtastic/install/install_generator.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module Formtastic
   # Copies a config initializer to config/initializers/formtastic.rb

--- a/lib/generators/templates/formtastic.rb
+++ b/lib/generators/templates/formtastic.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 # Set the default text field size when input is a string. Default is nil.
 # Formtastic::FormBuilder.default_text_field_size = 50

--- a/script/integration-template.rb
+++ b/script/integration-template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 gem 'formtastic', path: '..'
 gem 'bcrypt', '~> 3.1.7'
 gem 'rails-dom-testing', group: :test

--- a/spec/action_class_finder_spec.rb
+++ b/spec/action_class_finder_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 require 'formtastic/action_class_finder'
 

--- a/spec/actions/button_action_spec.rb
+++ b/spec/actions/button_action_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'ButtonAction', 'when submitting' do

--- a/spec/actions/button_action_spec.rb
+++ b/spec/actions/button_action_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'ButtonAction', 'when submitting' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -25,7 +25,7 @@ RSpec.describe 'ButtonAction', 'when resetting' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -48,7 +48,7 @@ RSpec.describe 'InputAction', 'when cancelling' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   

--- a/spec/actions/generic_action_spec.rb
+++ b/spec/actions/generic_action_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'InputAction::Base' do

--- a/spec/actions/generic_action_spec.rb
+++ b/spec/actions/generic_action_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'InputAction::Base' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -484,7 +484,7 @@ RSpec.describe 'InputAction::Base' do
   describe 'when the model is two words' do
 
     before do
-      output_buffer = ''
+      output_buffer = ActiveSupport::SafeBuffer.new ''
       class ::UserPost
         extend ActiveModel::Naming if defined?(ActiveModel::Naming)
         include ActiveModel::Conversion if defined?(ActiveModel::Conversion)

--- a/spec/actions/input_action_spec.rb
+++ b/spec/actions/input_action_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'InputAction', 'when submitting' do

--- a/spec/actions/input_action_spec.rb
+++ b/spec/actions/input_action_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'InputAction', 'when submitting' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -25,7 +25,7 @@ RSpec.describe 'InputAction', 'when resetting' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -44,7 +44,7 @@ RSpec.describe 'InputAction', 'when cancelling' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   

--- a/spec/actions/link_action_spec.rb
+++ b/spec/actions/link_action_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'LinkAction', 'when cancelling' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -58,7 +58,7 @@ RSpec.describe 'LinkAction', 'when submitting' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -77,7 +77,7 @@ RSpec.describe 'LinkAction', 'when submitting' do
   include FormtasticSpecHelper
   
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   

--- a/spec/actions/link_action_spec.rb
+++ b/spec/actions/link_action_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'LinkAction', 'when cancelling' do

--- a/spec/builder/custom_builder_spec.rb
+++ b/spec/builder/custom_builder_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do

--- a/spec/builder/custom_builder_spec.rb
+++ b/spec/builder/custom_builder_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Formtastic::Helpers::FormHelper.builder' do
   end
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/builder/error_proc_spec.rb
+++ b/spec/builder/error_proc_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Rails field_error_proc' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/builder/error_proc_spec.rb
+++ b/spec/builder/error_proc_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Rails field_error_proc' do

--- a/spec/builder/semantic_fields_for_spec.rb
+++ b/spec/builder/semantic_fields_for_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#fields_for' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     allow(@new_post).to receive(:author).and_return(::Author.new)
   end

--- a/spec/builder/semantic_fields_for_spec.rb
+++ b/spec/builder/semantic_fields_for_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::FormBuilder#fields_for' do

--- a/spec/fast_spec_helper.rb
+++ b/spec/fast_spec_helper.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 $LOAD_PATH << 'lib/formtastic'
 require 'active_support/all'
 require 'localized_string'

--- a/spec/generators/formtastic/form/form_generator_spec.rb
+++ b/spec/generators/formtastic/form/form_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 # Generators are not automatically loaded by Rails

--- a/spec/generators/formtastic/form/form_generator_spec.rb
+++ b/spec/generators/formtastic/form/form_generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Formtastic::FormGenerator do
   destination File.expand_path("../../../../../tmp", __FILE__)
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     prepare_destination
     mock_everything
     allow(::Post).to receive(:reflect_on_all_associations).with(:belongs_to).and_return([

--- a/spec/generators/formtastic/input/input_generator_spec.rb
+++ b/spec/generators/formtastic/input/input_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 require 'generators/formtastic/input/input_generator'

--- a/spec/generators/formtastic/install/install_generator_spec.rb
+++ b/spec/generators/formtastic/install/install_generator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 # Generators are not automatically loaded by Rails

--- a/spec/helpers/action_helper_spec.rb
+++ b/spec/helpers/action_helper_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'with action class finder' do

--- a/spec/helpers/actions_helper_spec.rb
+++ b/spec/helpers/actions_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#actions' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/helpers/actions_helper_spec.rb
+++ b/spec/helpers/actions_helper_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::FormBuilder#actions' do

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'FormHelper' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -155,6 +155,12 @@ RSpec.describe 'FormHelper' do
     end
 
     describe 'ActionView::Base.field_error_proc' do
+      around do |ex|
+        error_proc = Formtastic::Helpers::FormHelper.formtastic_field_error_proc
+        ex.run
+        Formtastic::Helpers::FormHelper.formtastic_field_error_proc = error_proc
+      end
+
       it 'is set to no-op wrapper by default' do
         semantic_form_for(@new_post, :url => '/hello') do |builder|
           expect(::ActionView::Base.field_error_proc.call("html", nil)).to eq("html")

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'FormHelper' do

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'with input class finder' do

--- a/spec/helpers/inputs_helper_spec.rb
+++ b/spec/helpers/inputs_helper_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::FormBuilder#inputs' do

--- a/spec/helpers/inputs_helper_spec.rb
+++ b/spec/helpers/inputs_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -171,8 +171,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
             builder.inputs(:for => [:author, @bob]) do
               #
             end
-          }.to raise_error(ArgumentError, 'You gave :for option with a block to inputs method, ' <<
-                                              'but the block does not accept any argument.')
+          }.to raise_error(ArgumentError, 'You gave :for option with a block to inputs method, but the block does not accept any argument.')
         end
       end
   
@@ -401,7 +400,7 @@ RSpec.describe 'Formtastic::FormBuilder#inputs' do
 
       context "with non-standard foregin keys" do
         before do
-          @output_buffer = ''
+          @output_buffer = ActiveSupport::SafeBuffer.new ''
         end
 
         it 'should respect foreign key while rendering select' do

--- a/spec/helpers/reflection_helper_spec.rb
+++ b/spec/helpers/reflection_helper_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::Helpers::Reflection' do

--- a/spec/helpers/reflection_helper_spec.rb
+++ b/spec/helpers/reflection_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::Helpers::Reflection' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/helpers/semantic_errors_helper_spec.rb
+++ b/spec/helpers/semantic_errors_helper_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do

--- a/spec/helpers/semantic_errors_helper_spec.rb
+++ b/spec/helpers/semantic_errors_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     @title_errors = ['must not be blank', 'must be awesome']
     @base_errors = ['base error message', 'nasty error']

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Formtastic::I18n' do
     include FormtasticSpecHelper
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       ::I18n.backend.store_translations :en, {:formtastic => {

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::I18n' do

--- a/spec/input_class_finder_spec.rb
+++ b/spec/input_class_finder_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 require 'formtastic/input_class_finder'
 

--- a/spec/inputs/base/collections_spec.rb
+++ b/spec/inputs/base/collections_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'fast_spec_helper'
 require 'inputs/base/collections'
 

--- a/spec/inputs/base/validations_spec.rb
+++ b/spec/inputs/base/validations_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'fast_spec_helper'
 require 'active_model'
 require 'inputs/base/validations'

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'boolean input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -208,7 +208,7 @@ RSpec.describe 'boolean input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => "context2") do |builder|
@@ -224,7 +224,7 @@ RSpec.describe 'boolean input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'boolean input' do

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'check_boxes input' do

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe 'check_boxes input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
   describe 'for a has_many association' do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@fred) do |builder|
@@ -169,7 +169,7 @@ RSpec.describe 'check_boxes input' do
 
     describe 'when :hidden_fields is set to false' do
       before do
-        @output_buffer = ''
+        @output_buffer = ActiveSupport::SafeBuffer.new ''
         mock_everything
 
         concat(semantic_form_for(@fred) do |builder|
@@ -196,7 +196,7 @@ RSpec.describe 'check_boxes input' do
 
     describe 'when :disabled is set' do
       before do
-        @output_buffer = ''
+        @output_buffer = ActiveSupport::SafeBuffer.new ''
       end
 
       describe "no disabled items" do
@@ -286,7 +286,7 @@ RSpec.describe 'check_boxes input' do
 
     describe "when :label option is false" do
       before do
-        @output_buffer = ''
+        @output_buffer = ActiveSupport::SafeBuffer.new ''
         allow(@new_post).to receive(:author_ids).and_return(nil)
         concat(semantic_form_for(@new_post) do |builder|
           concat(builder.input(:authors, :as => :check_boxes, :label => false))
@@ -337,7 +337,7 @@ RSpec.describe 'check_boxes input' do
   describe 'for a has_and_belongs_to_many association' do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@freds_post) do |builder|
@@ -362,7 +362,7 @@ RSpec.describe 'check_boxes input' do
   describe ':collection for a has_and_belongs_to_many association' do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@freds_post) do |builder|
@@ -387,7 +387,7 @@ RSpec.describe 'check_boxes input' do
   describe 'for an association when a :collection is provided' do
     describe 'it should use the specified :member_value option' do
       before do
-        @output_buffer = ''
+        @output_buffer = ActiveSupport::SafeBuffer.new ''
         mock_everything
       end
 
@@ -410,7 +410,7 @@ RSpec.describe 'check_boxes input' do
 
   describe 'when :collection is provided as an array of arrays' do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
       allow(@fred).to receive(:genres) { ['fiction', 'biography'] }
 
@@ -427,7 +427,7 @@ RSpec.describe 'check_boxes input' do
 
   describe 'when :collection is a set' do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
       allow(@fred).to receive(:roles) { Set.new([:reviewer, :admin]) }
 
@@ -446,7 +446,7 @@ RSpec.describe 'check_boxes input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@fred, :namespace => "context2") do |builder|
@@ -465,7 +465,7 @@ RSpec.describe 'check_boxes input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@fred) do |builder|
@@ -492,7 +492,7 @@ RSpec.describe 'check_boxes input' do
 
   describe "when collection is an array" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       @_collection = [["First", 1], ["Second", 2]]
       mock_everything
 

--- a/spec/inputs/color_input_spec.rb
+++ b/spec/inputs/color_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'color input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'color input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/color_input_spec.rb
+++ b/spec/inputs/color_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'color input' do

--- a/spec/inputs/country_input_spec.rb
+++ b/spec/inputs/country_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'country input' do

--- a/spec/inputs/country_input_spec.rb
+++ b/spec/inputs/country_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'country input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -80,7 +80,7 @@ RSpec.describe 'country input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|

--- a/spec/inputs/custom_input_spec.rb
+++ b/spec/inputs/custom_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 # TODO extract out

--- a/spec/inputs/datalist_input_spec.rb
+++ b/spec/inputs/datalist_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe "datalist inputs" do

--- a/spec/inputs/datalist_input_spec.rb
+++ b/spec/inputs/datalist_input_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "datalist inputs" do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/date_picker_input_spec.rb
+++ b/spec/inputs/date_picker_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'date_picker input' do

--- a/spec/inputs/date_picker_input_spec.rb
+++ b/spec/inputs/date_picker_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'date_picker input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -412,7 +412,7 @@ RSpec.describe 'date_picker input' do
   
   describe "when index is provided" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/date_select_input_spec.rb
+++ b/spec/inputs/date_select_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'date select input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -74,7 +74,7 @@ RSpec.describe 'date select input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/date_select_input_spec.rb
+++ b/spec/inputs/date_select_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'date select input' do

--- a/spec/inputs/datetime_picker_input_spec.rb
+++ b/spec/inputs/datetime_picker_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'datetime_picker input' do

--- a/spec/inputs/datetime_picker_input_spec.rb
+++ b/spec/inputs/datetime_picker_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'datetime_picker input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -453,7 +453,7 @@ RSpec.describe 'datetime_picker input' do
   
   describe "when index is provided" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/datetime_select_input_spec.rb
+++ b/spec/inputs/datetime_select_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'datetime select input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -79,7 +79,7 @@ RSpec.describe 'datetime select input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/datetime_select_input_spec.rb
+++ b/spec/inputs/datetime_select_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'datetime select input' do

--- a/spec/inputs/email_input_spec.rb
+++ b/spec/inputs/email_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'email input' do

--- a/spec/inputs/email_input_spec.rb
+++ b/spec/inputs/email_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'email input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'email input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/file_input_spec.rb
+++ b/spec/inputs/file_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'file input' do

--- a/spec/inputs/file_input_spec.rb
+++ b/spec/inputs/file_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'file input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     concat(semantic_form_for(@new_post) do |builder|
@@ -33,7 +33,7 @@ RSpec.describe 'file input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
@@ -49,7 +49,7 @@ RSpec.describe 'file input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/hidden_input_spec.rb
+++ b/spec/inputs/hidden_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'hidden input' do

--- a/spec/inputs/hidden_input_spec.rb
+++ b/spec/inputs/hidden_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'hidden input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     concat(semantic_form_for(@new_post) do |builder|
@@ -64,7 +64,7 @@ RSpec.describe 'hidden input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
       
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
@@ -88,7 +88,7 @@ RSpec.describe 'hidden input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/include_blank_spec.rb
+++ b/spec/inputs/include_blank_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "*select: options[:include_blank]" do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     allow(@new_post).to receive(:author_id).and_return(nil)

--- a/spec/inputs/include_blank_spec.rb
+++ b/spec/inputs/include_blank_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe "*select: options[:include_blank]" do

--- a/spec/inputs/label_spec.rb
+++ b/spec/inputs/label_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::FormBuilder#label' do

--- a/spec/inputs/label_spec.rb
+++ b/spec/inputs/label_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/number_input_spec.rb
+++ b/spec/inputs/number_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'number input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
     
     allow(@new_post.class).to receive(:validators_on).with(:title).and_return([
@@ -71,7 +71,7 @@ RSpec.describe 'number input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/number_input_spec.rb
+++ b/spec/inputs/number_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'number input' do

--- a/spec/inputs/password_input_spec.rb
+++ b/spec/inputs/password_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'password input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     concat(semantic_form_for(@new_post) do |builder|
@@ -60,7 +60,7 @@ RSpec.describe 'password input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/password_input_spec.rb
+++ b/spec/inputs/password_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'password input' do

--- a/spec/inputs/phone_input_spec.rb
+++ b/spec/inputs/phone_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'phone input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'phone input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/phone_input_spec.rb
+++ b/spec/inputs/phone_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'phone input' do

--- a/spec/inputs/placeholder_spec.rb
+++ b/spec/inputs/placeholder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'string input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/placeholder_spec.rb
+++ b/spec/inputs/placeholder_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'string input' do

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'radio input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -216,7 +216,7 @@ RSpec.describe 'radio input' do
 
   describe "when :label option is false" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       allow(@new_post).to receive(:author_ids).and_return(nil)
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.input(:authors, :as => :radio, :label => false))
@@ -248,7 +248,7 @@ RSpec.describe 'radio input' do
 
   describe "when :namespace is given on form" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       allow(@new_post).to receive(:author_ids).and_return(nil)
       concat(semantic_form_for(@new_post, :namespace => "custom_prefix") do |builder|
         concat(builder.input(:authors, :as => :radio, :label => ''))
@@ -263,7 +263,7 @@ RSpec.describe 'radio input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|
@@ -290,7 +290,7 @@ RSpec.describe 'radio input' do
 
   describe "when collection contains integers" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(:project) do |builder|
@@ -307,7 +307,7 @@ RSpec.describe 'radio input' do
 
   describe "when collection contains symbols" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(:project) do |builder|

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'radio input' do

--- a/spec/inputs/range_input_spec.rb
+++ b/spec/inputs/range_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'range input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -46,7 +46,7 @@ RSpec.describe 'range input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/range_input_spec.rb
+++ b/spec/inputs/range_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'range input' do

--- a/spec/inputs/readonly_spec.rb
+++ b/spec/inputs/readonly_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'readonly option' do

--- a/spec/inputs/readonly_spec.rb
+++ b/spec/inputs/readonly_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'readonly option' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/search_input_spec.rb
+++ b/spec/inputs/search_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'search input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'search input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/search_input_spec.rb
+++ b/spec/inputs/search_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'search input' do

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'select input' do

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'select input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -522,7 +522,7 @@ RSpec.describe 'select input' do
 
   describe "enum" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       @some_meta_descriptions = ["One", "Two", "Three"]
       allow(@new_post).to receive(:meta_description).at_least(:once)
     end
@@ -573,7 +573,7 @@ RSpec.describe 'select input' do
   describe "when index is provided" do
   
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
   
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'string input' do

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'string input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -179,7 +179,7 @@ RSpec.describe 'string input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/text_input_spec.rb
+++ b/spec/inputs/text_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'text input' do

--- a/spec/inputs/text_input_spec.rb
+++ b/spec/inputs/text_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'text input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     concat(semantic_form_for(@new_post) do |builder|
@@ -67,7 +67,7 @@ RSpec.describe 'text input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
@@ -84,7 +84,7 @@ RSpec.describe 'text input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/time_picker_input_spec.rb
+++ b/spec/inputs/time_picker_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'time_picker input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
   
@@ -418,7 +418,7 @@ RSpec.describe 'time_picker input' do
   
   describe "when index is provided" do
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/time_picker_input_spec.rb
+++ b/spec/inputs/time_picker_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'time_picker input' do

--- a/spec/inputs/time_select_input_spec.rb
+++ b/spec/inputs/time_select_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'time select input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/time_select_input_spec.rb
+++ b/spec/inputs/time_select_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'time select input' do

--- a/spec/inputs/time_zone_input_spec.rb
+++ b/spec/inputs/time_zone_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'time_zone input' do

--- a/spec/inputs/time_zone_input_spec.rb
+++ b/spec/inputs/time_zone_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'time_zone input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
 
     concat(semantic_form_for(@new_post) do |builder|
@@ -41,7 +41,7 @@ RSpec.describe 'time_zone input' do
   describe "when namespace is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
@@ -58,7 +58,7 @@ RSpec.describe 'time_zone input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/url_input_spec.rb
+++ b/spec/inputs/url_input_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'url input' do

--- a/spec/inputs/url_input_spec.rb
+++ b/spec/inputs/url_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'url input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'url input' do
   describe "when index is provided" do
 
     before do
-      @output_buffer = ''
+      @output_buffer = ActiveSupport::SafeBuffer.new ''
       mock_everything
 
       concat(semantic_form_for(@new_post) do |builder|

--- a/spec/inputs/with_options_spec.rb
+++ b/spec/inputs/with_options_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'string input' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/inputs/with_options_spec.rb
+++ b/spec/inputs/with_options_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'string input' do

--- a/spec/localizer_spec.rb
+++ b/spec/localizer_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'Formtastic::Localizer' do

--- a/spec/namespaced_class_finder_spec.rb
+++ b/spec/namespaced_class_finder_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 require 'formtastic/namespaced_class_finder'
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveRecord::Schema.define(version: 20170208011723) do
 
   create_table "posts", force: :cascade do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'rubygems'
 require 'bundler/setup'
 require 'active_support'

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module CustomMacros
 

--- a/spec/support/deprecation.rb
+++ b/spec/support/deprecation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 def with_deprecation_silenced(&block)
   ::ActiveSupport::Deprecation.silence do
     yield

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -2,7 +2,7 @@ RSpec.shared_context 'form builder' do
   include FormtasticSpecHelper
 
   before do
-    @output_buffer = ''
+    @output_buffer = ActiveSupport::SafeBuffer.new ''
     mock_everything
   end
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.shared_context 'form builder' do
   include FormtasticSpecHelper
 

--- a/spec/support/specialized_class_finder_shared_example.rb
+++ b/spec/support/specialized_class_finder_shared_example.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 #
 RSpec.shared_examples 'Specialized Class Finder' do
   let(:builder) { Formtastic::FormBuilder.allocate }

--- a/spec/support/test_environment.rb
+++ b/spec/support/test_environment.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'rspec/core'
 
 require 'rspec-dom-testing'


### PR DESCRIPTION
- Makes the tests a bit more accurate in replicating what `output_buffer` looks like in a Rails app.
- Adds `# frozen_string_literal: true` to all `*.rb` files
- Replaced string literal mutation in as many places as possible