### PR TITLE
Fix I18n lookup for enum values in nested select fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    formtastic (4.0.0.rc1)
+    formtastic (4.0.0)
       actionpack (>= 5.2.0)
 
 GEM

--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -114,7 +114,7 @@ module Formtastic
 
             enum_options_hash = object.defined_enums[method_name]
             enum_options_hash.map do |name, value|
-              key = "activerecord.attributes.#{object_name}.#{method_name.pluralize}.#{name}"
+              key = "activerecord.attributes.#{object.model_name.i18n_key}.#{method_name.pluralize}.#{name}"
               label = ::I18n.translate(key, :default => name.humanize)
               [label, name]
             end

--- a/spec/inputs/base/collections_spec.rb
+++ b/spec/inputs/base/collections_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe MyInput do
         statuses = ActiveSupport::HashWithIndifferentAccess.new("active"=>0, "inactive"=>1)
         allow(model_class).to receive(:statuses) { statuses }
         allow(model).to receive(:defined_enums) { {"status" => statuses } }
+        allow(model).to receive(:model_name).and_return(double(i18n_key: model_name))
       end
 
       context 'no translations available' do


### PR DESCRIPTION
This PR accomplishes the same as #1227, albeit with a more focused approach.
When constructing the key for looking up the localized enum value, we now use [`ActiveModel::Name.i18n_key`](https://api.rubyonrails.org/classes/ActiveModel/Name.html) instead of `object_name`, which returned something like `user[posts_attributes][0]` in case of nested forms.
I've added a test that reproduces the exact scenario that triggered the fixed bug (#1151).

Bonus: I've added a commit to update Formtastic version in Gemfile.lock (it was still 4.0.0.rc1).  

Fixes #1151
Supersedes #1227 