### PR TITLE
Create CI job that aggregates matrix status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
 
 jobs:
+  ci:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
   test:
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
It is useful to have just one commit status with the action result. Right now there is a status for each matrix job.