### PR TITLE
Remove redundant option setting

### DIFF
--- a/lib/generators/formtastic/form/form_generator.rb
+++ b/lib/generators/formtastic/form/form_generator.rb
@@ -33,7 +33,7 @@ module Formtastic
     class_option :copy, :type => :boolean, :default => false, :group => :formtastic,
     :desc => 'Copy the generated code the clipboard instead of generating a partial file."'
 
-    class_option :controller, :type => :string, :default => false, :group => :formtastic,
+    class_option :controller, :type => :string, :group => :formtastic,
     :desc => 'Generate for custom controller/view path - in case model and controller namespace is different, i.e. "admin/posts"'
 
     def create_or_show


### PR DESCRIPTION
This setting causes:
```
This will be rejected in the future unless you explicitly pass the options `check_default_type: false` or call `allow_incompatible_default_type!` in your code
```
warning because option type (string) is incompatible with the default value (false). I'm not sure why there is `default: false` for controller name, probably it's ok to remove it