### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,15 +23,11 @@ jobs:
           - gemfiles/rails_edge/Gemfile
 
         ruby:
-          - 2.5.8
           - 2.6.6
           - 2.7.2
           - 3.0.0
 
         exclude:
-          - ruby: 2.5.8
-            gemfile: gemfiles/rails_edge/Gemfile
-
           - ruby: 2.6.6
             gemfile: gemfiles/rails_edge/Gemfile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
  * Support for Rails under 6.0.0 has been dropped ([#1354](https://github.com/formtastic/formtastic/pull/1354))
- * Support for rubies under 2.5.0 has been dropped ([#1332](https://github.com/formtastic/formtastic/pull/1332))
+ * Support for rubies under 2.6.0 has been dropped ([#1332](https://github.com/formtastic/formtastic/pull/1332), [#1355](https://github.com/formtastic/formtastic.git/pull/1355))
  * Support for scopes in relations ([#1343](https://github.com/formtastic/formtastic/pull/1343))
  * Fix I18n lookup for enum values in nested select fields ([#1342](https://github.com/formtastic/formtastic/pull/1342))
  * Fixed faster input class lookup ([#1336](https://github.com/formtastic/formtastic/pull/1336))

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far e
 
 ## Compatibility
 
-* Formtastic master requires Rails 6.0 and Ruby 2.5 minimum
+* Formtastic master requires Rails 6.0 and Ruby 2.6 minimum
 * Formtastic 4 requires Rails 5.2 and Ruby 2.4 minimum
 * Formtastic 3 requires Rails 3.2.13 minimum
 * Formtastic 2 requires Rails 3

--- a/formtastic.gemspec
+++ b/formtastic.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.rubygems_version = %q{1.3.6}
 


### PR DESCRIPTION
It reached its End of Life period at April, the 5th, 2021. See
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/.