### PR TITLE
Remove `autoload` for non-existent ButtonsHelper

### DIFF
--- a/lib/formtastic/helpers.rb
+++ b/lib/formtastic/helpers.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 module Formtastic
   module Helpers
-    autoload :ButtonsHelper, 'formtastic/helpers/buttons_helper'
     autoload :ActionHelper, 'formtastic/helpers/action_helper'
     autoload :ActionsHelper, 'formtastic/helpers/actions_helper'
     autoload :ErrorsHelper, 'formtastic/helpers/errors_helper'


### PR DESCRIPTION
This pull request removes an unnecessary `autoload` statement for `ButtonsHelper`, which was removed from formtastic in https://github.com/formtastic/formtastic/commit/9ccff73ae07207e11f78a580934ee8c3a8ebf94b.