### PR TITLE
Use latest Bundler consistenly in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          bundler: latest
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Old Bundler versions will always resolve git gems from the "master" branch but some gems in our Gemfiles use "main".

Use modern Bundler versions that handle this fine.

This fixes CI in the master branch.