### PR TITLE
adding a label_html option to customize label tag

### DIFF
--- a/lib/formtastic/helpers/input_helper.rb
+++ b/lib/formtastic/helpers/input_helper.rb
@@ -177,6 +177,9 @@ module Formtastic
       # @example Changing or adding to HTML attributes in the main `<input>` or `<select>` tag
       #   <%= f.input :title, :input_html => { :onchange => "somethingAwesome();", :class => 'awesome' } %>
       #
+      # @example Changing or adding to HTML attributes in the main `<label>` tag
+      #   <%= f.input :title, :label_html => { :data => { :tooltip => 'Great Tooltip' } } %>
+      #
       # @example Changing or adding to HTML attributes in the wrapper `<li>` tag
       #   <%= f.input :title, :wrapper_html => { :class => "important-input" } %>
       #

--- a/lib/formtastic/inputs/base/labelling.rb
+++ b/lib/formtastic/inputs/base/labelling.rb
@@ -14,7 +14,7 @@ module Formtastic
           {
             :for => input_html_options[:id],
             :class => ['label'],
-          }
+          }.merge(options[:label_html] || {})
         end
         
         def label_text

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -731,6 +731,17 @@ RSpec.describe 'with input class finder' do
 
     end
 
+    describe ':label_method option' do
+      it "should allow label_html to add custom attributes" do
+        concat(semantic_form_for(@new_post) do |builder|
+          concat(builder.input(:title, :label_html => { :data => { :tooltip => 'Great Tooltip' } }))
+        end)
+        aggregate_failures do
+          expect(output_buffer.to_str).to have_tag('form li label[data-tooltip="Great Tooltip"]')
+        end
+      end
+    end
+
     describe ':hint option' do
 
       describe 'when provided' do

--- a/spec/inputs/label_spec.rb
+++ b/spec/inputs/label_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
     expect(output_buffer.to_str).to have_tag('label', :text => /Title/)
   end
 
+  it 'should apply a "for" attribute to the label' do
+    concat(semantic_form_for(@new_post) do |builder|
+      builder.input(:title)
+    end)
+    puts output_buffer.to_str
+    expect(output_buffer.to_str).to have_tag('label[for=post_title]')
+  end
+
+  it 'should apply a "label" class to the label' do
+    concat(semantic_form_for(@new_post) do |builder|
+      builder.input(:title)
+    end)
+    expect(output_buffer.to_str).to have_tag('label.label')
+  end
+
   it 'should use i18n instead of the method name when method given as a String' do
     with_config :i18n_cache_lookups, true do
       ::I18n.backend.store_translations :en, { :formtastic => { :labels => { :post => { :title => "I18n title" } } } }
@@ -66,6 +81,24 @@ RSpec.describe 'Formtastic::FormBuilder#label' do
       expect(output_buffer.to_str).to have_tag('label abbr', '*')
     end
   end
+
+  describe "when label_html is given" do
+    it "should allow label_html to override the class" do
+      concat(semantic_form_for(@new_post) do |builder|
+        builder.input(:title, :label_html => { :class => 'my_class' } )
+      end)
+      expect(output_buffer.to_str).to have_tag('label.my_class', /Title/)
+    end
+
+    it "should allow label_html to add custom attributes" do
+      concat(semantic_form_for(@new_post) do |builder|
+        builder.input(:title, :label_html => { :data => { :tooltip => 'Great Tooltip' } } )
+      end)
+      aggregate_failures do
+        expect(output_buffer.to_str).to have_tag('label[data-tooltip="Great Tooltip"]')
+      end
+    end
+  end 
 
   describe 'when a collection is given' do
     it 'should use a supplied label_method for simple collections' do


### PR DESCRIPTION
This is something I monkey patch routinely in my projects.
It allows to overwrite `:class`, `:for` attributes, as well as adding custom attributes like `data-*`.
I find this very useful for it to work with stimulus and javascript frameworks/plugins.
I added specs where I thought it made sense. Not sure if you guys require to test each input individually