### PR TITLE
Passing caller is deprecated

### DIFF
--- a/lib/formtastic/inputs/base.rb
+++ b/lib/formtastic/inputs/base.rb
@@ -22,7 +22,7 @@ module Formtastic
       # Usefull for deprecating options.
       def warn_and_correct_option!(old_option_name, new_option_name)
         if options.key?(old_option_name)
-          Deprecation.warn("The :#{old_option_name} option is deprecated in favour of :#{new_option_name} and will be removed from Formtastic in the next version", caller(6))
+          Deprecation.warn("The :#{old_option_name} option is deprecated in favour of :#{new_option_name} and will be removed from Formtastic in the next version", caller_locations(6))
           options[new_option_name] = options.delete(old_option_name)
         end
       end
@@ -30,7 +30,7 @@ module Formtastic
       # Usefull for deprecating options.
       def warn_deprecated_option!(old_option_name, instructions)
         if options.key?(old_option_name)
-          Deprecation.warn("The :#{old_option_name} option is deprecated in favour of `#{instructions}`. :#{old_option_name} will be removed in the next version", caller(6))
+          Deprecation.warn("The :#{old_option_name} option is deprecated in favour of `#{instructions}`. :#{old_option_name} will be removed in the next version", caller_locations(6))
         end
       end
 


### PR DESCRIPTION
Passing the result of `caller` to `Deprecation#warn` was deprecated for Rails 7.2 in #50054 and will be removed in Rails 8.