### PR TITLE
Update doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Formtastic is a Rails FormBuilder DSL (with some other goodies) to make it far e
 
 ## Documentation & Support
 
-* [Documentation is available on rdoc.info](https://rdoc.info/projects/formtastic/formtastic)
+* [Documentation is available on rubydoc.info](https://www.rubydoc.info/github/formtastic/formtastic)
 * [We track issues & bugs on GitHub](https://github.com/formtastic/formtastic/issues)
 * [We have a wiki on GitHub](https://github.com/formtastic/formtastic/wiki)
 * [StackOverflow can help](https://stackoverflow.com/questions/tagged/formtastic)


### PR DESCRIPTION
rdoc.info does not work, and has been replaced by [rubydoc.info](https://github.com/docmeta/rubydoc.info): 

> RubyDoc.info is the next generation Ruby doc server, replacing http://rdoc.info/ and http://yardoc.org/docs.
