### PR TITLE
Accessibility improvements for inline errors and semantic_errors

### DIFF
--- a/lib/formtastic/helpers/errors_helper.rb
+++ b/lib/formtastic/helpers/errors_helper.rb
@@ -42,23 +42,31 @@ module Formtastic
       def semantic_errors(*args)
         html_options = args.extract_options!
         args = args - [:base]
-        full_errors = args.inject([]) do |array, method|
-          attribute = localized_string(method, method.to_sym, :label) || humanized_attribute_name(method)
-          errors = Array(@object.errors[method.to_sym]).to_sentence
-          errors.present? ? array << [attribute, errors].join(" ") : array ||= []
+        full_errors = {}
+        args.each do |attribute|
+          full_errors[attribute] = error_message_for_attribute(attribute)
         end
-        full_errors << @object.errors[:base]
-        full_errors.flatten!
-        full_errors.compact!
-        return nil if full_errors.blank?
+        full_errors.compact_blank!
+        base_errors = @object.errors[:base]
+        base_errors = Array(@object.errors[:base]) if base_errors.is_a?(String)
+        return nil if full_errors.blank? && base_errors.blank?
         html_options[:class] ||= "errors"
         template.content_tag(:ul, html_options) do
-          full_errors.map { |error| template.content_tag(:li, error) }.join.html_safe
+          (
+            base_errors.map { |base_error| template.content_tag(:li, base_error) } <<
+            full_errors.map { |attribute, error_message|
+              template.content_tag(:li) do
+                template.content_tag(:a, href: "##{object_name}_#{attribute}") do
+                  error_message
+                end
+              end
+            }
+          ).join.html_safe
         end
       end
-      
+
       protected
-      
+
       def error_keys(method, options)
         @methods_for_error ||= {}
         @methods_for_error[method] ||= begin
@@ -76,6 +84,16 @@ module Formtastic
 
       def render_inline_errors?
         @object && @object.respond_to?(:errors) && Formtastic::FormBuilder::INLINE_ERROR_TYPES.include?(inline_errors)
+      end
+
+      def error_message_for_attribute(attribute)
+        attribute_string = localized_string(attribute, attribute.to_sym, :label) || humanized_attribute_name(attribute)
+        error_message = @object.errors[attribute.to_sym]&.to_sentence
+
+        return nil if error_message.blank?
+
+        full_message = [attribute_string, error_message].join(" ")
+        full_message
       end
     end
   end

--- a/lib/formtastic/inputs/base/errors.rb
+++ b/lib/formtastic/inputs/base/errors.rb
@@ -10,7 +10,7 @@ module Formtastic
         
         def error_sentence_html
           error_class = builder.default_inline_error_class
-          template.content_tag(:p, errors.to_sentence, :class => error_class)
+          template.content_tag(:p, errors.to_sentence, id: "#{method}_error", :class => error_class)
         end
                 
         def error_list_html

--- a/lib/formtastic/inputs/base/html.rb
+++ b/lib/formtastic/inputs/base/html.rb
@@ -20,12 +20,17 @@ module Formtastic
         end
 
         def input_html_options
-          {
+          opts = {
             :id => dom_id,
             :required => required_attribute?,
             :autofocus => autofocus?,
             :readonly => readonly?
           }.merge(options[:input_html] || {})
+          if errors?
+            opts['aria-invalid'] ||= true
+            opts['aria-describedby'] = "#{opts['aria-describedby']} #{method}_error "
+          end
+          opts
         end
 
         def dom_id

--- a/spec/builder/semantic_fields_for_spec.rb
+++ b/spec/builder/semantic_fields_for_spec.rb
@@ -111,6 +111,8 @@ RSpec.describe 'Formtastic::FormBuilder#fields_for' do
         end)
       end)
       expect(output_buffer.to_str).to match(/oh noes/)
+      expect(output_buffer.to_str).to include('aria-invalid="true"')
+      expect(output_buffer.to_str).to include("aria-describedby", "login_error")
     end
 
   end

--- a/spec/helpers/semantic_errors_helper_spec.rb
+++ b/spec/helpers/semantic_errors_helper_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
         expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', :text => title_name << " " << @title_errors.to_sentence)
       end
     end
+
+    it 'should have a href to the input field' do
+      semantic_form_for(@new_post) do |builder|
+        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li a', with: { href: "##{@new_post.model_name}_title" } )
+      end
+    end
   end
 
   describe 'when there are errors on title and base' do


### PR DESCRIPTION
This PR attempts to improve accessibility of Form errors when inline errors are being rendered, and gives `semantic_errors` links to errored inputs. The goal of the PR is to maintain existing functionality and backward compatibility while providing some enhancements to Forms that have errors

1. The `semantic_errors` method is updated to render list items, and when the error is a model attribute, automatically render itself as a link to the errored input.
2. Add ids to inline errors, and automatically update `aria-describedby` the inline error id, and `aria-invalid` set to true.

**Semantic errors**
Followed this gov uk guide to inform improvements of the `semantic_errors`
https://design-system.service.gov.uk/components/error-summary/


**Inline errors**
This guide informed my decision to add aria attributes 
https://www.smashingmagazine.com/2023/02/guide-accessible-form-validation/#the-error-message

The inline error paragraph is updated for the most common error method, `error_sentence_html`, such that the id is automatically set to `"#{method_error}"`
The `input_html_options` when `errors?` is `true` become: `aria-invalid=true`, `aria-describedby="inline_error_id"`

**Code sandbox**

<img width="800" alt="Screenshot 2025-03-17 at 6 51 06 PM" src="https://github.com/user-attachments/assets/25bb6131-f679-4341-9ef4-f7985bc933d3" />

