### PR TITLE
Add symbols to raw_collection types that won't be mapped

### DIFF
--- a/lib/formtastic/inputs/base/collections.rb
+++ b/lib/formtastic/inputs/base/collections.rb
@@ -53,7 +53,7 @@ module Formtastic
 
           # Return if we have an Array of strings, integers or arrays
           return raw_collection if (raw_collection.instance_of?(Array) || raw_collection.instance_of?(Range)) &&
-                               ([Array, String].include?(raw_collection.first.class) || raw_collection.first.is_a?(Integer)) &&
+                               ([Array, String, Symbol].include?(raw_collection.first.class) || raw_collection.first.is_a?(Integer)) &&
                                !(options.include?(:member_label) || options.include?(:member_value))
 
           raw_collection.map { |o| [send_or_call(label_method, o), send_or_call(value_method, o)] }

--- a/spec/inputs/base/collections_spec.rb
+++ b/spec/inputs/base/collections_spec.rb
@@ -74,5 +74,48 @@ RSpec.describe MyInput do
     end
   end
 
+  describe '#collection' do
+
+    context 'when the raw collection is a string' do
+      it 'returns the string' do
+        instance.stub(:raw_collection) { "one_status_only" }
+        instance.collection.should eq "one_status_only"
+      end
+    end
+
+    context 'when the raw collection is an array of strings' do
+      it 'returns the array of symbols' do
+        instance.stub(:raw_collection) { ["active", "inactive", "pending"] }
+        instance.collection.instance_of?(Array).should eq(true)
+        instance.collection.should eq ["active", "inactive", "pending"]
+      end
+    end
+
+    context 'when the raw collection is an array of arrays' do
+      it 'returns the array of arrays' do
+        instance.stub(:raw_collection) { [["inactive", "0"], ["active", "1"], ["pending", "2"]] }
+        instance.collection.instance_of?(Array).should eq(true)
+        instance.collection.should eq [["inactive", "0"], ["active", "1"], ["pending", "2"]]
+      end
+    end
+
+    context 'when the raw collection is an array of symbols' do
+      it 'returns the array of symbols' do
+        instance.stub(:raw_collection) { [:active, :inactive, :pending] }
+        instance.collection.instance_of?(Array).should eq(true)
+        instance.collection.should eq [:active, :inactive, :pending]
+      end
+    end
+
+    context 'when the raw collection is a hash' do
+      it 'will be mapped into array form' do
+        instance.stub(:raw_collection) { { inactive: 0, active: 1, pending: 2 } }
+        instance.collection.instance_of?(Array).should eq(true)
+        instance.collection.should eq [[:inactive, 0], [:active, 1], [:pending, 2]]
+      end
+    end
+
+  end
+
 end
 


### PR DESCRIPTION
Originally proposed in #1160 by @Morred, tweaked to apply cleanly
Fixes #1127