### PR TITLE
Fix inferred maxlength for :integer columns

### DIFF
--- a/lib/formtastic/inputs/base/validations.rb
+++ b/lib/formtastic/inputs/base/validations.rb
@@ -183,7 +183,22 @@ module Formtastic
         end
 
         def column_limit
-          column.limit if column? && column.respond_to?(:limit)
+          return unless column?
+          return unless column.respond_to?(:limit)
+
+          limit = column.limit # already in characters for string, text, etc
+
+          if column.type == :integer && column.limit.is_a?(Integer)
+            return {
+              1 => 3, # 8 bit
+              2 => 5, # 16 bit
+              3 => 7, # 24 bit
+              4 => 10, # 32 bit
+              8 => 19, # 64 bit
+            }[limit] || nil
+          end
+
+          return limit
         end
 
         def limit

--- a/spec/inputs/password_input_spec.rb
+++ b/spec/inputs/password_input_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'password input' do
   it_should_have_input_with_id("post_title")
   it_should_have_input_with_type(:password)
   it_should_have_input_with_name("post[title]")
-  it_should_have_maxlength_matching_column_limit
+  it_should_have_maxlength_matching_string_column_limit
   it_should_use_default_text_field_size_when_not_nil(:string)
   it_should_not_use_default_text_field_size_when_nil(:string)
   it_should_apply_custom_input_attributes_when_input_html_provided(:string)

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'string input' do
     before do
       concat(semantic_form_for(@new_post) do |builder|
         concat(builder.input(:title, :as => :string))
+        concat(builder.input(:status, :as => :string))
       end)
     end
 
@@ -27,7 +28,8 @@ RSpec.describe 'string input' do
     it_should_have_input_with_id("post_title")
     it_should_have_input_with_type(:text)
     it_should_have_input_with_name("post[title]")
-    it_should_have_maxlength_matching_column_limit
+    it_should_have_maxlength_matching_string_column_limit
+    it_should_have_maxlength_matching_integer_column_limit
     it_should_use_default_text_field_size_when_not_nil(:string)
     it_should_not_use_default_text_field_size_when_nil(:string)
     it_should_apply_custom_input_attributes_when_input_html_provided(:string)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -365,6 +365,7 @@ module FormtasticSpecHelper
     end
 
     allow(@new_post).to receive(:title)
+    allow(@new_post).to receive(:status)
     allow(@new_post).to receive(:email)
     allow(@new_post).to receive(:url)
     allow(@new_post).to receive(:phone)
@@ -390,6 +391,7 @@ module FormtasticSpecHelper
     allow(@new_post).to receive(:document).and_return(@mock_file)
     allow(@new_post).to receive(:column_for_attribute).with(:meta_description).and_return(double('column', :type => :string, :limit => 255))
     allow(@new_post).to receive(:column_for_attribute).with(:title).and_return(double('column', :type => :string, :limit => 50))
+    allow(@new_post).to receive(:column_for_attribute).with(:status).and_return(double('column', :type => :integer, :limit => 1))
     allow(@new_post).to receive(:column_for_attribute).with(:body).and_return(double('column', :type => :text))
     allow(@new_post).to receive(:column_for_attribute).with(:published).and_return(double('column', :type => :boolean))
     allow(@new_post).to receive(:column_for_attribute).with(:publish_at).and_return(double('column', :type => :date))

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -171,10 +171,19 @@ module CustomMacros
       end
     end
 
-    def it_should_have_maxlength_matching_column_limit
+    def it_should_have_maxlength_matching_string_column_limit
       it 'should have a maxlength matching column limit' do
+        expect(@new_post.column_for_attribute(:title).type).to eq(:string)
         expect(@new_post.column_for_attribute(:title).limit).to eq(50)
         expect(output_buffer.to_str).to have_tag("form li input[@maxlength='50']")
+      end
+    end
+
+    def it_should_have_maxlength_matching_integer_column_limit
+      it 'should have a maxlength matching column limit' do
+        expect(@new_post.column_for_attribute(:status).type).to eq(:integer)
+        expect(@new_post.column_for_attribute(:status).limit).to eq(1)
+        expect(output_buffer.to_str).to have_tag("form li input[@maxlength='3']")
       end
     end
 


### PR DESCRIPTION
Postgres and MySQL column limits aren't directly usable as character lengths, as they're provided in byte lengths. When developers want to use a string input instead of a numeric input, this would result in a maxlen of 1 for an 8 bit column, rather than a maxlen of 3, 2 instead of 5 for a 16 bit, etc.

This translates the bits into characters.

Fixes #1377