### PR TITLE
Add helper methods for semantic_errors building logic

### DIFF
--- a/lib/formtastic/helpers/errors_helper.rb
+++ b/lib/formtastic/helpers/errors_helper.rb
@@ -43,7 +43,7 @@ module Formtastic
         html_options = args.extract_options!
         html_options[:class] ||= "errors"
 
-        full_errors = semantic_error_list_from_base
+        full_errors = @object.errors[:base]
         full_errors += semantic_error_list_from_attributes(args)
         return nil if full_errors.blank?
 
@@ -71,16 +71,6 @@ module Formtastic
 
       def render_inline_errors?
         @object && @object.respond_to?(:errors) && Formtastic::FormBuilder::INLINE_ERROR_TYPES.include?(inline_errors)
-      end
-
-      def semantic_error_list_from_base
-        if @object.errors[:base].is_a?(Array)
-          @object.errors[:base]
-        else
-          # ActiveModel::Errors :base should be an array, we could remove this conditional
-          # still need to confirm String base errors are supported in Rails
-          Array(@object.errors[:base])
-        end
       end
 
       def semantic_error_list_from_attributes(*args)

--- a/spec/helpers/semantic_errors_helper_spec.rb
+++ b/spec/helpers/semantic_errors_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
     mock_everything
     @title_errors = ['must not be blank', 'must be awesome']
     @base_errors = ['base error message', 'nasty error']
-    @base_error = 'one base error'
+    @base_error = ['one base error']
     @errors = double('errors')
     allow(@new_post).to receive(:errors).and_return(@errors)
   end
@@ -23,7 +23,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
 
     it 'should render an unordered list' do
       semantic_form_for(@new_post) do |builder|
-        expect(builder.semantic_errors).to have_tag('ul.errors li', :text => @base_error)
+        expect(builder.semantic_errors).to have_tag('ul.errors li', text: 'one base error')
       end
     end
   end
@@ -67,15 +67,15 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
       semantic_form_for(@new_post) do |builder|
         title_name = builder.send(:localized_string, :title, :title, :label) || builder.send(:humanized_attribute_name, :title)
         expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', :text => title_name << " " << @title_errors.to_sentence)
-        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', :text => @base_error)
+        expect(builder.semantic_errors(:title)).to have_tag('ul.errors li', text: 'one base error')
       end
     end
   end
 
   describe 'when there are no errors' do
     before do
-      allow(@errors).to receive(:[]).with(errors_matcher(:title)).and_return(nil)
-      allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return(nil)
+      allow(@errors).to receive(:[]).with(errors_matcher(:title)).and_return([])
+      allow(@errors).to receive(:[]).with(errors_matcher(:base)).and_return([])
     end
 
     it 'should return nil' do
@@ -92,7 +92,7 @@ RSpec.describe 'Formtastic::FormBuilder#semantic_errors' do
 
     it 'should render an unordered list with given class' do
       semantic_form_for(@new_post) do |builder|
-        expect(builder.semantic_errors(:class => "awesome")).to have_tag('ul.awesome li', :text => @base_error)
+        expect(builder.semantic_errors(:class => "awesome")).to have_tag('ul.awesome li', text: 'one base error')
       end
     end
   end


### PR DESCRIPTION
### Description
This refactor was identified in #1388
We wanted to clean up the logic in the `semantic_errors(args*)` within the method

### Solution
Refactor the semantic_errors helper which does the following: 
- First get the array from the model's base errors with the `semantic_error_list_from_base` method
- Second get the array of attribute errors such as `:title, :synopsis, :isbn` when using this helper 
`<%= f.semantic_errors :title, :synopsis, :isbn, :publish_year %>`. 

  - `semantic_error_list_from_attributes(args)` encapsulates this logic.
- Render the result within a `<ul>` with each error as a `<li>` (Unchanged)

### Testing
- Tests in rspec pass
- Tested validation errors manually in a form, and also without errors
<img width="400" height="468" alt="Screenshot 2025-07-14 at 3 41 57 PM" src="https://github.com/user-attachments/assets/46116bb2-eb97-434b-a873-32c1a625ec0c" />
