### PR TITLE
[Docs] Fix config yard issue

### DIFF
--- a/lib/formtastic/form_builder.rb
+++ b/lib/formtastic/form_builder.rb
@@ -16,41 +16,40 @@ module Formtastic
       self.send(:"#{name}=", default)
     end
 
-    configure :custom_namespace
-    configure :default_text_field_size
-    configure :default_text_area_height, 20
-    configure :default_text_area_width
+    # Check {Formtastic::ActionClassFinder} to see how are inputs resolved.
+    configure :action_class_finder, Formtastic::ActionClassFinder
+    configure :action_namespaces, [::Object, ::Formtastic::Actions]
     configure :all_fields_required_by_default, true
-    configure :include_blank_for_select_by_default, true
-    configure :required_string, proc { %{<abbr title="#{Formtastic::I18n.t(:required)}">*</abbr>}.html_safe }
-    configure :optional_string, ''
-    configure :inline_errors, :sentence
-    configure :label_str_method, :humanize
     configure :collection_label_methods, %w[to_label display_name full_name name title username login value to_s]
     configure :collection_value_methods, %w[id to_s]
-    configure :file_methods, [ :file?, :public_filename, :filename ]
-    configure :file_metadata_suffixes, ['content_type', 'file_name', 'file_size']
-    configure :priority_countries, ["Australia", "Canada", "United Kingdom", "United States"]
-    configure :i18n_lookups_by_default, true
-    configure :i18n_cache_lookups, true
-    configure :i18n_localizer, Formtastic::Localizer
-    configure :escape_html_entities_in_hints_and_labels, true
+    configure :custom_namespace
     configure :default_commit_button_accesskey
-    configure :default_inline_error_class, 'inline-errors'
     configure :default_error_list_class, 'errors'
     configure :default_hint_class, 'inline-hints'
-    configure :semantic_errors_link_to_inputs, false
-    configure :use_required_attribute, false
-    configure :perform_browser_validations, false
+    configure :default_inline_error_class, 'inline-errors'
+    configure :default_text_area_height, 20
+    configure :default_text_area_width
+    configure :default_text_field_size
+    configure :escape_html_entities_in_hints_and_labels, true
+    configure :file_metadata_suffixes, ['content_type', 'file_name', 'file_size']
+    configure :file_methods, [ :file?, :public_filename, :filename ]
+    configure :i18n_cache_lookups, true
+    configure :i18n_localizer, Formtastic::Localizer
+    configure :i18n_lookups_by_default, true
+    configure :include_blank_for_select_by_default, true
+    configure :inline_errors, :sentence
     # Check {Formtastic::InputClassFinder} to see how are inputs resolved.
-    configure :input_namespaces, [::Object, ::Formtastic::Inputs]
     configure :input_class_finder, Formtastic::InputClassFinder
-    # Check {Formtastic::ActionClassFinder} to see how are inputs resolved.
-    configure :action_namespaces, [::Object, ::Formtastic::Actions]
-    configure :action_class_finder, Formtastic::ActionClassFinder
-
-    configure :skipped_columns, [:created_at, :updated_at, :created_on, :updated_on, :lock_version, :version]
+    configure :input_namespaces, [::Object, ::Formtastic::Inputs]
+    configure :label_str_method, :humanize
+    configure :optional_string, ''
+    configure :perform_browser_validations, false
+    configure :priority_countries, ["Australia", "Canada", "United Kingdom", "United States"]
     configure :priority_time_zones, []
+    configure :required_string, proc { %{<abbr title="#{Formtastic::I18n.t(:required)}">*</abbr>}.html_safe }
+    configure :semantic_errors_link_to_inputs, false
+    configure :skipped_columns, [:created_at, :updated_at, :created_on, :updated_on, :lock_version, :version]
+    configure :use_required_attribute, false
 
     attr_reader :template
 


### PR DESCRIPTION
Resolves #1395 

### Solution
used the sort-lines vscode extension, moved the comments above what they describe

**before**
<img width="309" height="824" alt="Screenshot 2025-08-07 at 8 38 12 PM" src="https://github.com/user-attachments/assets/11343d1f-fa24-45ab-9dd2-20aa7d0c89bc" />
**after**
The comments appear underneath config fields, where before they were in the wrong place because yard would auto-alphabetize
<img width="317" height="831" alt="Screenshot 2025-08-07 at 8 39 37 PM" src="https://github.com/user-attachments/assets/a4d77a06-1257-4497-a06e-ee248d846617" />